### PR TITLE
Bug Fix: Problem in parameter value dialog

### DIFF
--- a/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/viewdatadialog/ViewDataUniqueIdDialog.java
+++ b/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/viewdatadialog/ViewDataUniqueIdDialog.java
@@ -44,6 +44,7 @@ public class ViewDataUniqueIdDialog extends Dialog{
 	private String selectedUniqueJobId;
 	private String[] titles = {"Job Id", "Time Stamp", "Execution Mode", "Job Status"};
 	private Table table;
+	private boolean okPressed;
 	
 	public ViewDataUniqueIdDialog(Shell parentShell, List<JobDetails> jobDetails) {
 		super(parentShell);
@@ -124,6 +125,7 @@ public class ViewDataUniqueIdDialog extends Dialog{
 		if(selectedUniqueJobId == null){
 			selectedUniqueJobId = jobDetails.get(0).getUniqueJobID();
 		}
+		okPressed = true;
 		super.okPressed();
 	}
 	
@@ -131,6 +133,13 @@ public class ViewDataUniqueIdDialog extends Dialog{
 	protected void cancelPressed() {
 		selectedUniqueJobId = "";
 		super.cancelPressed();
+	}
+	
+	@Override
+	public boolean close(){
+		if(!okPressed)
+		selectedUniqueJobId = "";
+		return super.close();
 	}
 	
 	private String getTimeStamp(String jobId){

--- a/hydrograph.ui/hydrograph.ui.parametergrid/src/main/java/hydrograph/ui/parametergrid/dialog/MultiParameterFileDialog.java
+++ b/hydrograph.ui/hydrograph.ui.parametergrid/src/main/java/hydrograph/ui/parametergrid/dialog/MultiParameterFileDialog.java
@@ -821,9 +821,9 @@ public class MultiParameterFileDialog extends Dialog {
 						if (StringUtils.isNotEmpty(paramterValueDialog
 								.getParamterValue())) {
 							String newParameterValue = paramterValueDialog
-									.getParamterValue().replaceAll("\r", "")
-									.replaceAll("\n", "").replaceAll("\t", "")
-									.replace("  ", "");
+									.getParamterValue().replaceAll("\r", " ")
+									.replaceAll("\n", " ").replaceAll("\t", " ")
+									.replace("  ", " ");
 							parameters.get(index).setParameterValue(
 									newParameterValue);
 						}else{

--- a/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/Release_Notes_March_2017.txt
+++ b/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/Release_Notes_March_2017.txt
@@ -8,3 +8,5 @@ Issues/Defects fixed:
 =====================================================================================================
 Sr.No. <GitHub Issue #>  - [fixed by] - description
 1. <> - [Pooja Yadav] - Job_Log name should contain "Project name _JobRunID" currently Job_Log name contain "Project Name.JobName_unique_number".
+2.<> - [Kalyan Rajpoot] - after editing the value in parameter value dialog when open that again , multi line was appended in single line without any spaces and become non legible.
+3.<> - [Kalyan Rajpoot] - data viewer window 'close' button was acting like 'ok' button.


### PR DESCRIPTION
Problem: after editing the value in parameter value dialog when open that again , multi line was appended in single line without any spaces and become non legible.
Solution : before saving the parameter value in the property file , replaced the '\n'  to single space(" ") so that multi line was appended in single line with any spaces so that it should be legible.