### PR TITLE
Bug/job log name change

### DIFF
--- a/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/job/AbstractJobLauncher.java
+++ b/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/job/AbstractJobLauncher.java
@@ -97,7 +97,7 @@ abstract public class AbstractJobLauncher {
 	 * @return
 	 */
 	protected JobLogger initJobLogger(DefaultGEFCanvas gefCanvas,boolean logSystemInfo,boolean logJobStartInfo, String jobRunId) {
-		final JobLogger joblogger = new JobLogger(gefCanvas.getActiveProject(), gefCanvas.getJobName());
+		final JobLogger joblogger = new JobLogger(gefCanvas.getActiveProject(), gefCanvas.getJobName(), jobRunId);
 		if(logJobStartInfo)
 			joblogger.logJobStartInfo(jobRunId);;
 		

--- a/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/job/JobManager.java
+++ b/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/job/JobManager.java
@@ -640,7 +640,7 @@ public class JobManager {
 	 * @return the job logger
 	 */
 	public JobLogger initJobLogger(DefaultGEFCanvas gefCanvas) {
-		final JobLogger joblogger = new JobLogger(gefCanvas.getActiveProject(), gefCanvas.getJobName());
+		final JobLogger joblogger = new JobLogger(gefCanvas.getActiveProject(), gefCanvas.getJobName(), gefCanvas.getUniqueJobId());
 		return joblogger;
 	}
 

--- a/hydrograph.ui/hydrograph.ui.joblogger/src/main/java/hydrograph/ui/joblogger/JobLogger.java
+++ b/hydrograph.ui/hydrograph.ui.joblogger/src/main/java/hydrograph/ui/joblogger/JobLogger.java
@@ -44,10 +44,12 @@ public class JobLogger {
 		
 	private String projectName;
 	private String jobName;
+	private String jobRunId;
 	
-	public JobLogger(String projectName, String jobName ){
+	public JobLogger(String projectName, String jobName,String jobRunId){
 		this.projectName = projectName;
 		this.jobName = jobName;
+		this.jobRunId = jobRunId;
 		registerLoggers();
 		logger.debug("Registered all loggers");
 	}
@@ -55,7 +57,7 @@ public class JobLogger {
 	
 	private void registerLoggers(){
 		loggers = new ArrayList<>();
-		loggers.add(new FileLogger(projectName, jobName));
+		loggers.add(new FileLogger(projectName, jobName, jobRunId));
 		logger.debug("Registred file logger");
 		loggers.add(new ConsoleLogger(projectName, jobName));
 		logger.debug("Registered Console logger");

--- a/hydrograph.ui/hydrograph.ui.joblogger/src/main/java/hydrograph/ui/joblogger/logger/FileLogger.java
+++ b/hydrograph.ui/hydrograph.ui.joblogger/src/main/java/hydrograph/ui/joblogger/logger/FileLogger.java
@@ -41,13 +41,14 @@ import hydrograph.ui.logging.factory.LogFactory;
  * @author Bitwise
  */
 public class FileLogger extends AbstractJobLogger{
-	private static final String YYYY_M_MDD_H_HMMSS = "yyyyMMdd_HHmmss";
 	private static final Logger logger = LogFactory.INSTANCE.getLogger(FileLogger.class);
 	public static String LOGGER_FOLDER_PATH = Platform.getInstallLocation().getURL().getPath();
 	private final static String APPEND_PATH="config"+File.separator+"logger"+File.separator+"job_logs"+File.separator;
 	public final String JOB_LOGS_ERROR = "Job_Logs will not be created in your workspace. Delete or Move Job_Logs to another location for smooth creation of logs.";
 	
 	private BufferedWriter logFileStream;
+	private String  projectName;
+	private String jobRunId;
 	
 	/**
 	 * 
@@ -56,9 +57,10 @@ public class FileLogger extends AbstractJobLogger{
 	 * @param projectName - name of active project
 	 * @param jobName - name of current job
 	 */
-	public FileLogger(String projectName, String jobName) {
+	public FileLogger(String projectName, String jobName, String jobRunId) {
 		super(projectName, jobName);
-		
+		this.projectName = projectName;
+		this.jobRunId = jobRunId;
 		initLogFileStream();
 		logger.debug("Initialized file logger");
 	}
@@ -84,11 +86,8 @@ public class FileLogger extends AbstractJobLogger{
 	 * 
 	 */
 	private void initLogFileStream() {
-		Date date = new Date() ;
-		SimpleDateFormat dateFormat = new SimpleDateFormat(YYYY_M_MDD_H_HMMSS) ;
-		
-	   
-		logger.debug("Created logfile- " + getFullJobName() + "_" +  dateFormat.format(date) + ".log");
+
+		logger.debug("Created logfile- " + this.projectName + "_" + this.jobRunId+ ".log");
 		
 		
 			LOGGER_FOLDER_PATH = LOGGER_FOLDER_PATH + APPEND_PATH;
@@ -97,7 +96,7 @@ public class FileLogger extends AbstractJobLogger{
 			File job_logs_folder = new File(LOGGER_FOLDER_PATH);
 			if (job_logs_folder.exists()) {
 				if (job_logs_folder.isDirectory()) {
-					File file = new File(LOGGER_FOLDER_PATH + getFullJobName() + "_" + dateFormat.format(date) + ".log");
+					File file = new File(LOGGER_FOLDER_PATH + this.projectName + "_" + this.jobRunId+ ".log");
 					logFileStream = new BufferedWriter(new FileWriter(file, true));
 				} else {
 					Status status = new Status(IStatus.ERROR, Activator.PLUGIN_ID, JOB_LOGS_ERROR);
@@ -105,7 +104,7 @@ public class FileLogger extends AbstractJobLogger{
 				}
 			} else {
 				job_logs_folder.mkdir();
-				File file = new File(LOGGER_FOLDER_PATH + getFullJobName() + "_" + dateFormat.format(date) + ".log");
+				File file = new File(LOGGER_FOLDER_PATH + this.projectName + "_" + this.jobRunId+ ".log");
 				logFileStream = new BufferedWriter(new FileWriter(file, true));
 			}
 			logger.debug("Created job log file stream");

--- a/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/Release_Notes_March_2017.txt
+++ b/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/Release_Notes_March_2017.txt
@@ -1,0 +1,10 @@
+====================================================================================================
+Features Added:
+=====================================================================================================
+Sr.No. <date> - [developer names] - description
+
+=====================================================================================================
+Issues/Defects fixed:
+=====================================================================================================
+Sr.No. <GitHub Issue #>  - [fixed by] - description
+1. <> - [Pooja Yadav] - Job_Log name should contain "Project name _JobRunID" currently Job_Log name contain "Project Name.JobName_unique_number".

--- a/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/phase_3/Milestone_4.txt
+++ b/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/phase_3/Milestone_4.txt
@@ -90,3 +90,4 @@ Sr.No. <GitHub/Bugzilla Issue #>  - [fixed by] - description
 72.#755 - [Ashika Holkar] - Aggregate Component: User is unable to open component after importing job
 73.#757 - [Ashika Holkar] - Group Combine: Invalid expression error is displayed under error log after importing job 
 74.#760 - [Ashika Holkar] - Group Combine: UI issues on Mac
+75.#752 - [Pooja Yadav] - Job_Log name should contain "Project name_JobRunID".

--- a/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/phase_3/Milestone_4.txt
+++ b/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/phase_3/Milestone_4.txt
@@ -90,4 +90,3 @@ Sr.No. <GitHub/Bugzilla Issue #>  - [fixed by] - description
 72.#755 - [Ashika Holkar] - Aggregate Component: User is unable to open component after importing job
 73.#757 - [Ashika Holkar] - Group Combine: Invalid expression error is displayed under error log after importing job 
 74.#760 - [Ashika Holkar] - Group Combine: UI issues on Mac
-75.#752 - [Pooja Yadav] - Job_Log name should contain "Project name_JobRunID".


### PR DESCRIPTION
Issue:
Changing the job log file name to make it identifiable among number of job runs.
Solution:
Currently Job_Log name contains "projectName.jobName_timestamp" instead of this  Job_Log name should contain "Project name_JobRunID". Here JobRunId contains jobId and unique number, where for each run unique number will change.

