### PR TITLE
Udated version of commandline dependancy for excecution tracking client

### DIFF
--- a/hydrograph.server/hydrograph.server.execution.tracking/pom.xml
+++ b/hydrograph.server/hydrograph.server.execution.tracking/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>hydrograph</groupId>
 			<artifactId>hydrograph.engine.command-line</artifactId>
-			<version>0.1.spark-SNAPSHOT</version>
+			<version>0.1.spark</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
Dependency for hydrograph.engine.command-line is not getting resolved due version issue.
Version has been updated so that dependency can be resolved.
