### PR TITLE
Removed SNAPSHOT from engine jars

### DIFF
--- a/hydrograph.engine/version.gradle
+++ b/hydrograph.engine/version.gradle
@@ -11,26 +11,24 @@
  * limitations under the License.
  ******************************************************************************/
 ext.repo = Grgit.open()
-	version = new Version(major: 0, minor:1, revision: "spark", branch :ext.repo.branch.current.name)
+version = new Version(major: 0, minor: 1, revision: "spark", branch: ext.repo.branch.current.name)
 
 buildscript {
-repositories {
-    mavenCentral()
-  		}
-  dependencies {
-    classpath 'org.ajoberstar:gradle-git:1.3.0'
-  		}
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.ajoberstar:gradle-git:1.3.0'
+    }
 }
 
 import org.ajoberstar.grgit.*
+
 class Version {
-	int major, minor
-	String revision,branch
-	
-	String toString() {
-		if(branch=="master")
-	"$major.$minor.$revision${''}"
-		else
-		"$major.$minor.$revision${''}"
-		}
-	}
+    int major, minor
+    String revision, branch
+
+    String toString() {
+        "$major.$minor.$revision${''}"
+    }
+}

--- a/hydrograph.engine/version.gradle
+++ b/hydrograph.engine/version.gradle
@@ -31,6 +31,6 @@ class Version {
 		if(branch=="master")
 	"$major.$minor.$revision${''}"
 		else
-		"$major.$minor.$revision${'-SNAPSHOT'}"
+		"$major.$minor.$revision${''}"
 		}
 	}


### PR DESCRIPTION
Issue:    
  Jars generated as a part of build process are snapshot jars which is causing dependent  jars building failure.
Solution:
    Removed SNAPSHOT from the version.gradle file which is used for naming the jars which are created as a part of build process.