### PR TITLE
Issue : Exception occurrs while saving graph

### DIFF
--- a/hydrograph.ui/hydrograph.ui.engine/src/main/java/hydrograph/ui/engine/xpath/ComponentXpath.java
+++ b/hydrograph.ui/hydrograph.ui.engine/src/main/java/hydrograph/ui/engine/xpath/ComponentXpath.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -87,7 +88,7 @@ public class ComponentXpath {
 					addParameterAsAttribute(entry, nodeList);
 			}
 			TransformerFactory transformerFactory = TransformerFactory.newInstance();
-			transformerFactory.setFeature(Constants.DISALLOW_DOCTYPE_DECLARATION,true);
+			transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 			Transformer transformer = transformerFactory.newTransformer();
 			DOMSource source = new DOMSource(doc);
 			out.reset();


### PR DESCRIPTION
Issue : Exception occurred while adding disallow-doctype-decl feature on TransformserFactory. Due to which parametrization functionality was not working.

Resolution : Removed disallow-doctype-decl feature and added XMLConstants.FEATURE_SECURE_PROCESSING feature for secure processing TransformerFactory.