### PR TITLE
fix : Job is failing on remote run with ClassNotFound exception

### DIFF
--- a/hydrograph.ui/hydrograph.ui.product/resources/config/gradle/build/build.gradle
+++ b/hydrograph.ui/hydrograph.ui.product/resources/config/gradle/build/build.gradle
@@ -485,9 +485,9 @@ task executeRemoteJob() {
 				unixParameterFileList=unixParameterFileList.substring(0, unixParameterFileList.length() - 1);
 			}
 	
-	        println "executeRemoteJob: Executing command -cd "+properties.remoteDirectory+"/"+project.name+ " && " + properties.runUtility + " -xmlpath " +jobXML + " -libjars lib/" + jarName + " -paramfiles " + unixParameterFileList +" -jobid "+jobId+" -udfpath " + udfpath + " -isexecutiontracking " + isExecutionTracking  +" -trackingclientsocketport " + executionTrackingPort +" -loglevel " + loglevel
+	        println "executeRemoteJob: Executing command -cd "+properties.remoteDirectory+"/"+project.name+ " && " + properties.runUtility + " -xmlpath " +jobXML + " -libjars " +properties.remoteDirectory+"/"+project.name+"/lib/" + jarName + " -paramfiles " + unixParameterFileList +" -jobid "+jobId+" -udfpath " + udfpath + " -isexecutiontracking " + isExecutionTracking  +" -trackingclientsocketport " + executionTrackingPort +" -loglevel " + loglevel
 			
-			def command = "cd " +properties.remoteDirectory+"/"+project.name+ " && " + properties.runUtility + " -xmlpath " +jobXML + " -libjars lib/" + jarName + " -paramfiles " + unixParameterFileList +" -jobid "+jobId+" -udfpath " + udfpath + " -isexecutiontracking " + isExecutionTracking  +" -trackingclientsocketport " + executionTrackingPort  +" -loglevel " + loglevel
+			def command = "cd " +properties.remoteDirectory+"/"+project.name+ " && " + properties.runUtility + " -xmlpath " +jobXML + " -libjars " +properties.remoteDirectory+"/"+project.name+"/lib/" + jarName + " -paramfiles " + unixParameterFileList +" -jobid "+jobId+" -udfpath " + udfpath + " -isexecutiontracking " + isExecutionTracking  +" -trackingclientsocketport " + executionTrackingPort  +" -loglevel " + loglevel
 
 	   		sshToRemoteServer(host,username,password,command,keyfile,usepassword)
 	    }
@@ -565,8 +565,8 @@ task executeDebugRemoteJob() {
 	        def jobId = jobId;
 	        def basePath = basePath;
 	        
-	        println "executeDebugRemoteJob: Executing command -cd "+properties.remoteDirectory+"/"+project.name+ " && " + properties.runUtility + " -xmlpath " +jobXML + " -libjars lib/" + jarName + " -paramfiles " + unixParameterFileList+ " -debugxmlpath "+ debugJobXML + " -jobid " + jobId + " -basepath " + basePath + " -udfpath" + udfpath  + " -isexecutiontracking " + isExecutionTracking + " -trackingclientsocketport " + executionTrackingPort + " -loglevel " + loglevel
-	        def command="cd " +properties.remoteDirectory+"/"+project.name+ " && " + properties.runUtility + " -xmlpath " +jobXML + " -libjars lib/" + jarName + " -paramfiles " + unixParameterFileList+ " -debugxmlpath "+ debugJobXML + " -jobid " + jobId + " -basepath " + basePath + " -udfpath " + udfpath  + " -isexecutiontracking " + isExecutionTracking + " -trackingclientsocketport " + executionTrackingPort + " -loglevel " + loglevel
+	        println "executeDebugRemoteJob: Executing command -cd "+properties.remoteDirectory+"/"+project.name+ " && " + properties.runUtility + " -xmlpath " +jobXML + " -libjars " +properties.remoteDirectory+"/"+project.name+"/lib/" + jarName + " -paramfiles " + unixParameterFileList+ " -debugxmlpath "+ debugJobXML + " -jobid " + jobId + " -basepath " + basePath + " -udfpath" + udfpath  + " -isexecutiontracking " + isExecutionTracking + " -trackingclientsocketport " + executionTrackingPort + " -loglevel " + loglevel
+	        def command="cd " +properties.remoteDirectory+"/"+project.name+ " && " + properties.runUtility + " -xmlpath " +jobXML + " -libjars " +properties.remoteDirectory+"/"+project.name+"/lib/" + jarName + " -paramfiles " + unixParameterFileList+ " -debugxmlpath "+ debugJobXML + " -jobid " + jobId + " -basepath " + basePath + " -udfpath " + udfpath  + " -isexecutiontracking " + isExecutionTracking + " -trackingclientsocketport " + executionTrackingPort + " -loglevel " + loglevel
 			sshToRemoteServer(host,username,password,command,keyfile,usepassword)
 	    }
 	  }


### PR DESCRIPTION
Problem: Job is failing on remote run with ClassNotFound exception when operation class is present in Transform Component.
Solution: 
ClassNotFound exception is due to '-libjars' parameter value was not resolving because of relative path so changing the path from relative to absolute in build.gradle file of ELT project ('-libjars' parameter has been used in generating the command when calling the sshToRemoteServer() in executeRemoteJob() and executeDebugRemoteJob()).