### PR TITLE
For security purpose moved user name and password from connection url to option in Spark redshift input and output component

### DIFF
--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputSparkRedshiftComponent.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputSparkRedshiftComponent.scala
@@ -57,7 +57,7 @@ class InputSparkRedshiftComponent(inputRDBMSEntity: InputRDBMSEntity, iComponent
       + " reading data using query '" + selectQuery + "'")
 
     val connectionURL = "jdbc:redshift://" + inputRDBMSEntity.getHostName + ":" + inputRDBMSEntity.getPort() + "/" +
-      inputRDBMSEntity.getDatabaseName + "?user=" + inputRDBMSEntity.getUsername + "&password=" + inputRDBMSEntity.getPassword;
+      inputRDBMSEntity.getDatabaseName
 
     LOG.info("Connection  url for input Spark Redshift  component: " + connectionURL)
 
@@ -66,6 +66,8 @@ class InputSparkRedshiftComponent(inputRDBMSEntity: InputRDBMSEntity, iComponent
         .format("com.databricks.spark.redshift")
         .option("url", connectionURL)
         .option("query", selectQuery)
+        .option("user", inputRDBMSEntity.getUsername)
+        .option("password", inputRDBMSEntity.getPassword)
         .option("tempdir", inputRDBMSEntity.getTemps3dir)
 
       val df = getDataFrameReader(sparkSession.sparkContext.hadoopConfiguration,dataFrameReader, properties).load

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/OutputSparkRedshiftComponent.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/OutputSparkRedshiftComponent.scala
@@ -50,7 +50,7 @@ class OutputSparkRedshiftComponent(outputRDBMSEntity: OutputRDBMSEntity, oCompon
     properties.setProperty("driver", Constants.REDSHIFT_DRIVER_NAME)
 
     val connectionURL = "jdbc:redshift://" + outputRDBMSEntity.getHostName + ":" + outputRDBMSEntity.getPort() + "/" +
-      outputRDBMSEntity.getDatabaseName + "?user=" + outputRDBMSEntity.getUsername + "&password=" + outputRDBMSEntity.getPassword
+      outputRDBMSEntity.getDatabaseName
 
     LOG.info("Created Output Spark Redshift Component '" + outputRDBMSEntity.getComponentId
       + "' in Batch " + outputRDBMSEntity.getBatch
@@ -80,6 +80,8 @@ class OutputSparkRedshiftComponent(outputRDBMSEntity: OutputRDBMSEntity, oCompon
       .format("com.databricks.spark.redshift")
       .option("tempdir", outputRDBMSEntity.getTemps3dir)
       .option("url", connectionURL)
+      .option("user", outputRDBMSEntity.getUsername)
+      .option("password", outputRDBMSEntity.getPassword)
       .option("dbtable", outputRDBMSEntity.getTableName)
 
     getDataFrameWriter(oComponentsParams.getSparkSession().sparkContext.hadoopConfiguration, dataFrameWriter, properties).mode("append").save()


### PR DESCRIPTION
For security purpose, we can not display username and password in log, So to achieve this we can move username and password from Connection url to option in Spark redshift input and output component.