### PR TITLE
Bug fix/cyclic dependency core plugin

### DIFF
--- a/hydrograph.engine/hydrograph.engine.plugin/src/main/java/hydrograph/engine/flowmanipulation/FlowManipulationContext.java
+++ b/hydrograph.engine/hydrograph.engine.plugin/src/main/java/hydrograph/engine/flowmanipulation/FlowManipulationContext.java
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  *******************************************************************************/
-package hydrograph.engine.core.flowmanipulation;
+package hydrograph.engine.flowmanipulation;
 
 import hydrograph.engine.core.component.entity.elements.SchemaField;
 import hydrograph.engine.core.core.HydrographJob;
@@ -21,6 +21,7 @@ import hydrograph.engine.jaxb.commontypes.TypeProperties;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 /**
  * The Class FlowManipulationContext.
  *
@@ -38,7 +39,7 @@ public class FlowManipulationContext {
 	String[] args;
 
 	public FlowManipulationContext(HydrographJob hydrographJob, String[] args,
-			SchemaFieldHandler schemaFieldHandler, String jobId) {
+                                   SchemaFieldHandler schemaFieldHandler, String jobId) {
 		this.jaxbMainGraph = hydrographJob.getJAXBObject().getInputsOrOutputsOrStraightPulls();
 		this.jaxbJobLevelRuntimeProperties = hydrographJob.getJAXBObject().getRuntimeProperties();
 		this.graphName = hydrographJob.getJAXBObject().getName();

--- a/hydrograph.engine/hydrograph.engine.plugin/src/main/java/hydrograph/engine/flowmanipulation/FlowManipulationHandler.java
+++ b/hydrograph.engine/hydrograph.engine.plugin/src/main/java/hydrograph/engine/flowmanipulation/FlowManipulationHandler.java
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  *******************************************************************************/
-package hydrograph.engine.core.flowmanipulation;
+package hydrograph.engine.flowmanipulation;
 
 import hydrograph.engine.core.core.HydrographJob;
 import hydrograph.engine.core.props.OrderedProperties;
@@ -86,7 +86,7 @@ public class FlowManipulationHandler {
 		try {
 			Class pluginClass = Class.forName(clazz);
 			Constructor constructor = pluginClass.getDeclaredConstructor();
-			ManipulatorListener inst = (ManipulatorListener) constructor.newInstance();
+			hydrograph.engine.flowmanipulation.ManipulatorListener inst = (ManipulatorListener) constructor.newInstance();
 			return inst.execute(flowManipulationContext);
 		} catch (ClassNotFoundException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
 			throw new RuntimeException(e);

--- a/hydrograph.engine/hydrograph.engine.plugin/src/main/java/hydrograph/engine/flowmanipulation/ManipulatorListener.java
+++ b/hydrograph.engine/hydrograph.engine.plugin/src/main/java/hydrograph/engine/flowmanipulation/ManipulatorListener.java
@@ -10,11 +10,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  *******************************************************************************/
-package hydrograph.engine.core.flowmanipulation;
+package hydrograph.engine.flowmanipulation;
 
 import hydrograph.engine.jaxb.commontypes.TypeBaseComponent;
 
 import java.util.List;
+
 /**
  * The Interface ManipulatorListener.
  *

--- a/hydrograph.engine/hydrograph.engine.plugin/src/main/java/hydrograph/engine/plugin/batchbreak/BatchBreakPlugin.java
+++ b/hydrograph.engine/hydrograph.engine.plugin/src/main/java/hydrograph/engine/plugin/batchbreak/BatchBreakPlugin.java
@@ -16,8 +16,8 @@ package hydrograph.engine.plugin.batchbreak;
 
 import hydrograph.engine.core.component.entity.elements.SchemaField;
 import hydrograph.engine.core.entity.LinkInfo;
-import hydrograph.engine.core.flowmanipulation.FlowManipulationContext;
-import hydrograph.engine.core.flowmanipulation.ManipulatorListener;
+import hydrograph.engine.flowmanipulation.FlowManipulationContext;
+import hydrograph.engine.flowmanipulation.ManipulatorListener;
 import hydrograph.engine.core.utilities.SocketUtilities;
 import hydrograph.engine.jaxb.commontypes.*;
 import hydrograph.engine.jaxb.inputtypes.SequenceInputFile;

--- a/hydrograph.engine/hydrograph.engine.plugin/src/main/java/hydrograph/engine/plugin/debug/DebugPlugin.java
+++ b/hydrograph.engine/hydrograph.engine.plugin/src/main/java/hydrograph/engine/plugin/debug/DebugPlugin.java
@@ -13,8 +13,8 @@
 package hydrograph.engine.plugin.debug;
 
 import hydrograph.engine.core.component.entity.elements.SchemaField;
-import hydrograph.engine.core.flowmanipulation.FlowManipulationContext;
-import hydrograph.engine.core.flowmanipulation.ManipulatorListener;
+import hydrograph.engine.flowmanipulation.FlowManipulationContext;
+import hydrograph.engine.flowmanipulation.ManipulatorListener;
 import hydrograph.engine.core.utilities.PropertiesHelper;
 import hydrograph.engine.core.utilities.XmlUtilities;
 import hydrograph.engine.core.xmlparser.XmlParsingUtils;

--- a/hydrograph.engine/hydrograph.engine.spark/build.gradle
+++ b/hydrograph.engine/hydrograph.engine.spark/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     compile project(':hydrograph.engine.core')
     compile project(':hydrograph.engine.transformation')
     compile project(':hydrograph.engine.expression')
+    compile project(':hydrograph.engine.plugin')
     compileOnly name: 'oracle-ojdbc6-11.2.0.4'
     compile group: 'com.ibatis', name: 'ibatis2-common', version: '2.1.7.597'
     compile group: 'com.amazon.redshift', name: 'redshift-jdbc42', version: '1.2.1.1001'

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/executiontracking/plugin/ExecutionTrackingPlugin.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/executiontracking/plugin/ExecutionTrackingPlugin.scala
@@ -12,7 +12,7 @@
   *******************************************************************************/
 package hydrograph.engine.spark.executiontracking.plugin
 
-import hydrograph.engine.core.flowmanipulation.{FlowManipulationContext, ManipulatorListener}
+import hydrograph.engine.flowmanipulation.{FlowManipulationContext, ManipulatorListener}
 import hydrograph.engine.core.utilities.SocketUtilities
 import hydrograph.engine.execution.tracking.ComponentInfo
 import hydrograph.engine.jaxb.commontypes._

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/flow/HydrographRuntime.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/flow/HydrographRuntime.scala
@@ -16,7 +16,7 @@ import java.io.IOException
 import java.util.Properties
 
 import hydrograph.engine.core.core.{HydrographJob, HydrographRuntimeService}
-import hydrograph.engine.core.flowmanipulation.{FlowManipulationContext, FlowManipulationHandler}
+import hydrograph.engine.flowmanipulation.{FlowManipulationContext, FlowManipulationHandler}
 import hydrograph.engine.core.helper.JAXBTraversal
 import hydrograph.engine.core.props.OrderedProperties
 import hydrograph.engine.core.schemapropagation.SchemaFieldHandler


### PR DESCRIPTION
Added "hydrograph.engine.plugin" project dependency on "hydrograph.engine.spark" project

Moved below classes from "hydrograph.engine.core" to "hydrograph.engine.plugin" project :
FlowManipulationContext, FlowManipulationHandler and ManipulatorListener

Updated below classes to import above classes as required :
BatchBreakPlugin.java, DebugPlugin.java, ExecutionTrackingPlugin.sc