### PR TITLE
View Execution tracking enhancement to change tracking log path on each run

### DIFF
--- a/hydrograph.ui/hydrograph.ui.common.datastructures/META-INF/MANIFEST.MF
+++ b/hydrograph.ui/hydrograph.ui.common.datastructures/META-INF/MANIFEST.MF
@@ -15,8 +15,9 @@ Export-Package: hydrograph.ui.common.cloneableinterface,
  hydrograph.ui.datastructure.expression,
  hydrograph.ui.datastructure.property,
  hydrograph.ui.datastructure.property.mapping,
+ hydrograph.ui.datastructures.executiontracking,
+ hydrograph.ui.datastructures.metadata,
  hydrograph.ui.datastructures.parametergrid,
- hydrograph.ui.datastructures.parametergrid.filetype,
- hydrograph.ui.datastructures.metadata
+ hydrograph.ui.datastructures.parametergrid.filetype
 Import-Package: org.apache.commons.lang
 

--- a/hydrograph.ui/hydrograph.ui.common.datastructures/src/main/java/hydrograph/ui/datastructures/executiontracking/ViewExecutionTrackingDetails.java
+++ b/hydrograph.ui/hydrograph.ui.common.datastructures/src/main/java/hydrograph/ui/datastructures/executiontracking/ViewExecutionTrackingDetails.java
@@ -1,0 +1,113 @@
+/********************************************************************************
+ * Copyright 2016 Capital One Services, LLC and Bitwise, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package hydrograph.ui.datastructures.executiontracking;
+
+public class ViewExecutionTrackingDetails {
+	private boolean viewHistoryTracking = false;
+ 	private String selectedUniqueJobId;
+ 	private String selectedLogFilePath;
+ 	
+ 	/**
+ 	 * @param builder
+ 	 */
+ 	private ViewExecutionTrackingDetails(Builder builder) {
+ 		this.selectedUniqueJobId = builder.selectedUniqueJobId;
+ 		this.selectedLogFilePath = builder.selectedLogFilePath;
+ 		this.viewHistoryTracking = builder.viewHistoryTracking;
+ 	}
+ 	
+ 	
+ 	/**
+ 	 * The Class Builder
+ 	 * @author Bitwise
+ 	 *
+ 	 */
+ 	public static class Builder{
+ 		protected ViewExecutionTrackingDetails executionTrackingDetails;
+ 		//required parameter
+ 		private String selectedUniqueJobId;
+ 		private String selectedLogFilePath;
+ 		private boolean viewHistoryTracking = true;
+ 		
+ 		/**
+ 		 * @param selectedUniqueJobId
+ 		 * @param selectedLogFilePath
+ 		 * @param isRemoteMode
+ 		 * @param viewHistoryTracking
+ 		 */
+ 		public Builder(String selectedUniqueJobId, String selectedLogFilePath, boolean viewHistoryTracking){
+ 			this.selectedUniqueJobId = selectedUniqueJobId;
+ 			this.selectedLogFilePath = selectedLogFilePath;
+ 			this.viewHistoryTracking = viewHistoryTracking;
+ 		}
+ 		
+ 		/**
+ 		 * The Function will return new instance.
+ 		 * @return object
+ 		 */
+ 		public ViewExecutionTrackingDetails build(){
+ 			return new ViewExecutionTrackingDetails(this);
+ 		}
+ 		
+ 		/**
+ 		 * @param viewHistoryTracking
+ 		 * @return
+ 		 */
+ 		public Builder viewHistoryTracking(boolean viewHistoryTracking) {
+ 			this.viewHistoryTracking = viewHistoryTracking;
+ 			return this;
+ 		}
+ 		
+ 		/**
+ 		 * @param executionTrackingDetails
+ 		 * @return
+ 		 */
+ 		public Builder copy(ViewExecutionTrackingDetails executionTrackingDetails){
+ 			this.selectedUniqueJobId = executionTrackingDetails.selectedUniqueJobId;
+ 			this.selectedLogFilePath = executionTrackingDetails.selectedLogFilePath;
+ 			this.viewHistoryTracking = executionTrackingDetails.viewHistoryTracking;
+ 			
+ 			return this;
+ 		}
+ 	}
+ 	
+ 	/**
+ 	 * The Function will return selected run job id
+ 	 * @return job id
+ 	 */
+ 	public String getSelectedUniqueJobId(){
+ 		return selectedUniqueJobId;
+ 	}
+ 	
+ 	/**
+ 	 * The Function will return log file path
+ 	 * @return file path
+ 	 */
+ 	public String getSelectedLogFilePath(){
+ 		return selectedLogFilePath;
+ 	}
+ 
+ 	/**
+ 	 * @return
+ 	 */
+ 	public boolean isViewHistoryTracking(){
+ 		return viewHistoryTracking;
+ 	}
+
+	@Override
+	public String toString() {
+		return "ViewExecutionTrackingDetails [viewHistoryTracking=" + viewHistoryTracking + ", selectedUniqueJobId="
+				+ selectedUniqueJobId + ", selectedLogFilePath=" + selectedLogFilePath + "]";
+	}
+ 	
+}

--- a/hydrograph.ui/hydrograph.ui.communication/src/main/java/hydrograph/ui/communication/debugservice/constants/DebugServiceMethods.java
+++ b/hydrograph.ui/hydrograph.ui.communication/src/main/java/hydrograph/ui/communication/debugservice/constants/DebugServiceMethods.java
@@ -24,7 +24,7 @@ public class DebugServiceMethods {
 	public static final String GET_DEBUG_FILE_PATH = "/read";
 	public static final String DELETE_DEBUG_CSV_FILE="/deleteLocalDebugFile";
 	public static final String DELETE_BASEPATH_FILES="/delete";
-	public static final String GET_FILTERED_FILE_PATH = "/filter";
+	public static final String GET_FILTERED_FILE_PATH = "/sparkSqlFilter";
 	public static final String READ_METASTORE="/readFromMetastore";
 	public static final String TEST_CONNECTION="/getConnectionStatus";
 }

--- a/hydrograph.ui/hydrograph.ui.dataviewer/src/main/java/hydrograph/ui/dataviewer/filter/FilterValidator.java
+++ b/hydrograph.ui/hydrograph.ui.dataviewer/src/main/java/hydrograph/ui/dataviewer/filter/FilterValidator.java
@@ -220,7 +220,7 @@ public class FilterValidator {
 		if(FilterConstants.TYPE_BOOLEAN.equals(type)){
 			Boolean convertedBoolean = Boolean.valueOf(value);
 			if(!StringUtils.equalsIgnoreCase(convertedBoolean.toString(), value)){
-				return false;
+				throw new ParseException("",0); //dummy exception
 			}
 		}
 		else if(FilterConstants.TYPE_DOUBLE.equals(type)){

--- a/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/execution/tracking/replay/ViewExecutionHistoryDataDialog.java
+++ b/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/execution/tracking/replay/ViewExecutionHistoryDataDialog.java
@@ -16,6 +16,7 @@ import java.io.FileNotFoundException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.gef.ui.parts.GraphicalEditor;
@@ -43,6 +44,7 @@ import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
 
+import hydrograph.ui.datastructures.executiontracking.ViewExecutionTrackingDetails;
 import hydrograph.ui.graph.Messages;
 import hydrograph.ui.graph.editor.ELTGraphicalEditor;
 import hydrograph.ui.graph.execution.tracking.datastructure.ExecutionStatus;
@@ -249,7 +251,10 @@ public class ViewExecutionHistoryDataDialog extends Dialog {
 			if(getTrackingFilePath().trim().isEmpty()){
 				if(!StringUtils.isEmpty(getSelectedUniqueJobId())){
 					executionStatus= ViewExecutionHistoryUtility.INSTANCE.readJsonLogFile(getSelectedUniqueJobId(), JobManager.INSTANCE.isLocalMode(), 
-							ViewExecutionHistoryUtility.INSTANCE.getLogPath());
+							getSelectedIdFilePath(selectedUniqueJobId), true);
+					ViewExecutionHistoryUtility.INSTANCE.getSelectedTrackingDetailsForSubjob().clear();
+					ViewExecutionHistoryUtility.INSTANCE.addSelectedTrackingDetails(new ViewExecutionTrackingDetails.Builder(selectedUniqueJobId, 
+							getSelectedIdFilePath(selectedUniqueJobId), true).build());
 				}else{
 					super.okPressed();
 				}
@@ -314,5 +319,17 @@ public class ViewExecutionHistoryDataDialog extends Dialog {
 		
 		return timeStamp;
 	}
+	
+	/**
+ 	 * The Function will return file log path corresponding to selected run job id
+ 	 * @param selectedUniqueJobId
+ 	 * @return file path
+ 	 */
+ 	private String getSelectedIdFilePath(String selectedUniqueJobId){
+ 		Map<String, ViewExecutionTrackingDetails> trackingMap = ViewExecutionHistoryUtility.INSTANCE.getTrackingPathDetails();
+ 		ViewExecutionTrackingDetails trackingDetails = trackingMap.get(selectedUniqueJobId);
+ 		
+ 		return trackingDetails.getSelectedLogFilePath();
+ 	}
 	
 }

--- a/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/execution/tracking/utils/TrackingStatusUpdateUtils.java
+++ b/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/execution/tracking/utils/TrackingStatusUpdateUtils.java
@@ -183,7 +183,11 @@ public class TrackingStatusUpdateUtils {
 		if (!componentNameAndLink.isEmpty()) {
 			for (Map.Entry<String, SubjobDetails> entry : componentNameAndLink.entrySet()) {
 				for (ComponentStatus componentStatus : executionStatus.getComponentStatus()) {
-					if (entry.getKey().contains(componentStatus.getComponentId())) {
+					
+					String splitString[] = componentStatus.getComponentId().split("\\.");
+ 					String str1[] = entry.getKey().split("\\.");
+ 					String str2 =  str1.length >= splitString.length ? (String) entry.getKey().subSequence(0, entry.getKey().lastIndexOf('.')) : entry.getKey();
+ 					if (componentStatus.getComponentId().contains(str2)) {
 						List<String> portList = new ArrayList(componentStatus.getProcessedRecordCount().keySet());
 						for (String port : portList) {
 							if ((((SubjobDetails) entry.getValue()).getSourceTerminal()).equals(port)) {

--- a/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/job/JobManager.java
+++ b/hydrograph.ui/hydrograph.ui.graph/src/main/java/hydrograph/ui/graph/job/JobManager.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import hydrograph.ui.common.interfaces.parametergrid.DefaultGEFCanvas;
 import hydrograph.ui.common.util.MultiParameterFileUIUtils;
 import hydrograph.ui.common.util.OSValidator;
+import hydrograph.ui.datastructures.executiontracking.ViewExecutionTrackingDetails;
 import hydrograph.ui.datastructures.parametergrid.ParameterFile;
 import hydrograph.ui.datastructures.parametergrid.filetype.ParamterFileTypes;
 import hydrograph.ui.dataviewer.window.DebugDataViewer;
@@ -59,6 +60,7 @@ import hydrograph.ui.graph.execution.tracking.datastructure.ExecutionStatus;
 import hydrograph.ui.graph.execution.tracking.logger.ExecutionTrackingFileLogger;
 import hydrograph.ui.graph.execution.tracking.preferences.ExecutionPreferenceConstants;
 import hydrograph.ui.graph.execution.tracking.preferences.JobRunPreference;
+import hydrograph.ui.graph.execution.tracking.replay.ViewExecutionHistoryUtility;
 import hydrograph.ui.graph.execution.tracking.utils.TrackingDisplayUtils;
 import hydrograph.ui.graph.execution.tracking.windows.ExecutionTrackingConsole;
 import hydrograph.ui.graph.handler.JobHandler;
@@ -296,6 +298,7 @@ public class JobManager {
 		job.setUsername(runConfigDialog.getUsername());
 		job.setPassword(clusterPassword);
 		job.setHost(runConfigDialog.getHost());
+		job.setDebugMode(false);
 		job.setRemoteMode(runConfigDialog.isRemoteMode());
 		
 		if(runConfigDialog.isRemoteMode()){
@@ -318,6 +321,12 @@ public class JobManager {
 			}else{
 				previouslyExecutedJobs.get(job.getConsoleName()).setDebugMode(false);
 			}
+		}
+		if(job.isExecutionTrack()){
+			//add execution tracking details on job execution
+			ViewExecutionHistoryUtility.INSTANCE.addTrackingPathDetails(job.getUniqueJobId(), 
+					new ViewExecutionTrackingDetails.Builder(job.getUniqueJobId(), ViewExecutionHistoryUtility.INSTANCE.getTrackingLogPath(),
+							job.isExecutionTrack()).build());
 		}
 		
 		launchJob(job, gefCanvas, parameterGrid, xmlPath,getUserFunctionsPropertertyFile() ,externalSchemaFiles,subJobList);
@@ -406,6 +415,14 @@ public class JobManager {
 		gefCanvas.disableRunningJobResource();
 		
 		previouslyExecutedJobs.put(job.getConsoleName(), job);
+		
+		if(job.isExecutionTrack()){
+			//add execution tracking details on job execution
+			ViewExecutionHistoryUtility.INSTANCE.addTrackingPathDetails(job.getUniqueJobId(), 
+					new ViewExecutionTrackingDetails.Builder(job.getUniqueJobId(), ViewExecutionHistoryUtility.INSTANCE.getTrackingLogPath(),
+							job.isExecutionTrack()).build());
+		}
+		
 		launchJobWithDebugParameter(job, gefCanvas, parameterGrid, xmlPath, debugXmlPath,getUserFunctionsPropertertyFile() ,externalSchemaFiles,subJobList);
 		
 	}
@@ -528,7 +545,6 @@ public class JobManager {
 	 * @return the parameter file dialog
 	 */
 	private MultiParameterFileDialog getParameterFileDialog(){
-		
 	    String activeProjectLocation=MultiParameterFileUIUtils.getActiveProjectLocation();
 		List<ParameterFile> filepathList = new LinkedList<>();
 		

--- a/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/phase_3/Milestone_4.txt
+++ b/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/phase_3/Milestone_4.txt
@@ -92,3 +92,4 @@ Sr.No. <GitHub/Bugzilla Issue #>  - [fixed by] - description
 74.#760 - [Ashika Holkar] - Group Combine: UI issues on Mac
 75.#768 - [Vibhor Tyagi] - Subjob : If Subjob contains multiple out connection then view data and execution not work
 76.#780 - [Vibhor Tyagi] - View Data :- Tool do not show view data of prior runs (removes debug files)
+77.#526 [Vibhor Tyagi] - View Execution Tracking History : Incorrect popup File not exists is getting displayed


### PR DESCRIPTION
Fixed issue: while running the job , user can change 'Tracking log path' to create tracking logs in preferences.
If user change the tracking log path on each run. So, user should be able to check tracking status from 'View Execution History dialog' .
