### PR TITLE
Oracle, Mysql and Teradata performance enhancement

### DIFF
--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/entity/InputRDBMSEntity.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/entity/InputRDBMSEntity.java
@@ -20,11 +20,9 @@ import hydrograph.engine.core.component.entity.elements.OutSocket;
 import hydrograph.engine.core.component.entity.elements.SchemaField;
 
 import java.util.List;
+
 /**
- * The Class InputRDBMSEntity.
- *
- * @author Bitwise
- *
+ * @author bitwise1
  */
 public class InputRDBMSEntity extends InputOutputEntityBase {
     private List<OutSocket> outSocketList;
@@ -46,6 +44,92 @@ public class InputRDBMSEntity extends InputOutputEntityBase {
     private String schemaName;
     private String _interface;
     private String temps3dir;
+
+    private Integer numPartitionsValue;
+    private Integer upperBound;
+    private Integer lowerBound;
+    private String columnName;
+    private String fetchSize;
+    private String extraUrlParameters;
+
+
+    /**
+     * @param  'numPartitionsValue'
+     * @return Integer
+     * number of partitions in order to get optimized performance
+     * */
+    public Integer getNumPartitionsValue() {
+        return numPartitionsValue;
+    }
+
+    public void setNumPartitionsValue(Integer numPartitionsValue) {
+        this.numPartitionsValue = numPartitionsValue;
+    }
+
+    /**
+     * @param 'upperBound'
+     * @return Integer
+     * upper limit for the chosen column of integral type
+     * */
+    public Integer getUpperBound() {
+        return upperBound;
+    }
+
+    public void setUpperBound(Integer upperBound) {
+        this.upperBound = upperBound;
+    }
+
+    /**
+     * @param 'lowerBound'
+     * @return Integer
+     * lower limit for the chosen column of integral type
+     * */
+    public Integer getLowerBound() {
+        return lowerBound;
+    }
+
+    public void setLowerBound(Integer lowerBound) {
+        this.lowerBound = lowerBound;
+    }
+
+    /**
+     * @param 'columnName'
+     * @return String
+     * name of the column of integral type where partitioning needs to be done
+     */
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public void setColumnName(String columnName) {
+        this.columnName = columnName;
+    }
+
+    /**
+     * @param 'fetchSize'
+     * @return Integer
+     * a JDBC parameter in order to get more set of rows from the database per network trips
+     */
+    public String getFetchSize() {
+        return fetchSize;
+    }
+
+    public void setFetchSize(String fetchSize) {
+        this.fetchSize = fetchSize;
+    }
+
+    /**
+     * @param 'extraUrlParameters'
+     * @return String
+     * a parameters that is optional and can be set as per users preference
+     * */
+    public String getExtraUrlParameters() {
+        return extraUrlParameters;
+    }
+
+    public void setExtraUrlParameters(String extraUrlParameters) {
+        this.extraUrlParameters = extraUrlParameters;
+    }
 
     /**
      * @return temps3dir - ot type String

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/entity/OutputRDBMSEntity.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/entity/OutputRDBMSEntity.java
@@ -23,9 +23,7 @@ import hydrograph.engine.jaxb.commontypes.TypeFieldName;
 import java.util.List;
 
 /**
- * The Class OutputRDBMSEntity.
- *
- * @author Bitwise
+ * @author bitwise1
  *
  */
 public class OutputRDBMSEntity extends InputOutputEntityBase {
@@ -42,8 +40,6 @@ public class OutputRDBMSEntity extends InputOutputEntityBase {
 
     private String databaseType;
     private String loadType;
-    private Integer chunkSize;
-
     private String hostName;
     private Integer port;
     private String jdbcDriver;
@@ -52,6 +48,9 @@ public class OutputRDBMSEntity extends InputOutputEntityBase {
     private String driverType;
     private String _interface;
     private String temps3dir;
+
+    private String chunkSize;
+    private String extraUrlParamters;
 
     /**
      * @return temps3dir - of type String
@@ -309,14 +308,26 @@ public class OutputRDBMSEntity extends InputOutputEntityBase {
     /**
      * @return the chunkSize
      */
-    public Integer getChunkSize() {
+    public String getChunkSize() {
         return chunkSize;
     }
 
     /**
      * @param chunkSize the chunkSize to set
      */
-    public void setChunkSize(Integer chunkSize) {
+    public void setChunkSize(String chunkSize) {
         this.chunkSize = chunkSize;
+    }
+    /**
+     * @param 'extraUrlParameters'
+     * @return String
+     * a parameters that is optional and can be set as per users preference
+     * */
+    public String getExtraUrlParamters() {
+        return extraUrlParamters;
+    }
+
+    public void setExtraUrlParamters(String extraUrlParamters) {
+        this.extraUrlParamters = extraUrlParamters;
     }
 }

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputMysqlEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputMysqlEntityGenerator.java
@@ -122,7 +122,17 @@ public class InputMysqlEntityGenerator extends
         //fetchsize
         inputRDBMSEntity.setFetchSize(inputMysqlJaxb.getFetchSize()==null?null: inputMysqlJaxb.getFetchSize().getValue());
         //extra url parameters
-        inputRDBMSEntity.setExtraUrlParameters(inputMysqlJaxb.getExtraUrlParams()==null?null:inputMysqlJaxb.getExtraUrlParams().getValue());
+        //inputRDBMSEntity.setExtraUrlParameters(inputMysqlJaxb.getExtraUrlParams()==null?null:inputMysqlJaxb.getExtraUrlParams().getValue());
+        if(inputMysqlJaxb.getExtraUrlParams()!=null){
+            if(inputMysqlJaxb.getExtraUrlParams().getValue().contains(",")){
+                String correctedParams = inputMysqlJaxb.getExtraUrlParams().getValue().replace(",","&");
+
+                LOG.info("using extra url params as" + correctedParams);
+                inputRDBMSEntity.setExtraUrlParameters(correctedParams);
+            }
+        }else if(inputMysqlJaxb.getExtraUrlParams()==null){
+            inputRDBMSEntity.setExtraUrlParameters(null);
+        }
 
         /**END*/
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputOracleEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputOracleEntityGenerator.java
@@ -23,12 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 
-/**
- * The Class InputOracleEntityGenerator.
- *
- * @author Bitwise
- *
- */
+
 public class InputOracleEntityGenerator extends
 InputComponentGeneratorBase {
 
@@ -89,6 +84,60 @@ InputComponentGeneratorBase {
         } else {
             inputRDBMSEntity.setSchemaName(null);
         }
+
+        /**new parameters that has been added after the open source release*/
+        inputRDBMSEntity.setNumPartitionsValue(inputOracleJaxb.getNumPartitions() == null? Integer.MIN_VALUE:inputOracleJaxb.getNumPartitions().getValue().intValue());
+        if(inputOracleJaxb.getNumPartitions()!=null&&inputOracleJaxb.getNumPartitions().getValue().intValue()==0){
+            LOG.warn("The number of partitions has been entered as ZERO," +
+                    "\nThe Execution shall still continue but will work on a single" +
+                    "\npartition hence impacting performance");
+        }
+
+        /**
+         * @note : At first the check is made for the nullability of the partiton value; in case the partition
+         *          value goes missing, the upper bound, lower bound and column name must not hold a value as the
+         *          JDBCRDD has only two JDBC functions as the one which doesn't do any partitioning and does not accept
+         *          the values from the below parameters listed and the second one which does partitoning accepts the
+         *          aforementioned parameters. Absence of any one parameter may lead to undesirable outcomes
+         * */
+        if(inputOracleJaxb.getNumPartitions()==null){
+            inputRDBMSEntity.setUpperBound(0);
+            inputRDBMSEntity.setLowerBound(0);
+            inputRDBMSEntity.setColumnName("");
+        }
+        else {
+            if (inputOracleJaxb.getNumPartitions().getUpperBound() == null) {
+                throw new RuntimeException("Error in Input Oracle Component '"+inputOracleJaxb.getId()+"'  Upper bound cannot be NULL when numPartitions holds an integer value");
+            } else inputRDBMSEntity.setUpperBound(inputOracleJaxb.getNumPartitions().getUpperBound().getValue().intValue());
+
+            if (inputOracleJaxb.getNumPartitions().getLowerBound() == null) {
+                throw new RuntimeException("Error in Input Oracle Component '"+inputOracleJaxb.getId()+"'  Lower bound cannot be NULL when numPartitions holds an integer value");
+            } else inputRDBMSEntity.setLowerBound(inputOracleJaxb.getNumPartitions().getLowerBound().getValue().intValue());
+
+            if (inputOracleJaxb.getNumPartitions().getColumnName() == null) {
+                throw new RuntimeException("Error in Input Oracle Component '"+inputOracleJaxb.getId()+"' Column Name cannot be NULL when numPartitions holds an integer value");
+            } else inputRDBMSEntity.setColumnName(inputOracleJaxb.getNumPartitions().getColumnName().getValue());
+
+            if(inputOracleJaxb.getNumPartitions().getLowerBound().getValue()
+                    .intValue()==inputOracleJaxb.getNumPartitions().getUpperBound().getValue().intValue()){
+                LOG.warn("'"+inputOracleJaxb.getId()+"'The upper bound and the lower bound values are same! In this case there will only be\n" +
+                        "a single partition");
+            }
+            if(inputOracleJaxb.getNumPartitions().getLowerBound().getValue()
+                    .intValue()>inputOracleJaxb.getNumPartitions().getUpperBound().getValue().intValue()){
+                LOG.error("Error in Input Oracle Component '"+inputOracleJaxb.getId()+"'  Can\'t proceed with partitioning");
+                throw new RuntimeException("Error in Input Oracle Component '"+inputOracleJaxb.getId()+"'  The lower bound is greater than upper bound");
+
+            }
+
+        }
+        //fetchsize
+        inputRDBMSEntity.setFetchSize(inputOracleJaxb.getFetchSize()==null?null: inputOracleJaxb.getFetchSize().getValue());
+        //extra url parameters
+        inputRDBMSEntity.setExtraUrlParameters(inputOracleJaxb.getExtraUrlParams()==null?null:inputOracleJaxb.getExtraUrlParams().getValue());
+
+        /**END*/
+
     }
 
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/OutputMysqlEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/OutputMysqlEntityGenerator.java
@@ -102,8 +102,19 @@ public class OutputMysqlEntityGenerator extends OutputComponentGeneratorBase {
             //for batchsize which was named to chunksize since there is batch in the ETL tool as well
         outputRDBMSEntity.setChunkSize(jaxbOutputMysql.getChunkSize()==null?null:jaxbOutputMysql.getChunkSize().getValue());
             //extra url parameters has been
-        outputRDBMSEntity.setExtraUrlParamters(jaxbOutputMysql.getExtraUrlParams()==null?null:jaxbOutputMysql.getExtraUrlParams().getValue());
-         /**end**/
+        /*outputRDBMSEntity.setExtraUrlParamters(jaxbOutputMysql.getExtraUrlParams()==null?null:jaxbOutputMysql.getExtraUrlParams().getValue());*/
+        if(jaxbOutputMysql.getExtraUrlParams()!=null){
+            if(jaxbOutputMysql.getExtraUrlParams().getValue().contains(",")){
+                String correctedParams = jaxbOutputMysql.getExtraUrlParams().getValue().replace(",","&");
+
+                LOG.info("using extra url params as" + correctedParams);
+                outputRDBMSEntity.setExtraUrlParamters(correctedParams);
+            }
+        }else if(jaxbOutputMysql.getExtraUrlParams()==null){
+            outputRDBMSEntity.setExtraUrlParamters(null);
+        }
+
+        /**end**/
     }
 
     @Override

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/OutputMysqlEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/OutputMysqlEntityGenerator.java
@@ -22,12 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
-/**
- * The Class OutputMysqlEntityGenerator.
- *
- * @author Bitwise
- *
- */
+
 public class OutputMysqlEntityGenerator extends OutputComponentGeneratorBase {
 
     private Mysql jaxbOutputMysql;
@@ -77,7 +72,7 @@ public class OutputMysqlEntityGenerator extends OutputComponentGeneratorBase {
 
         outputRDBMSEntity.setPort(jaxbOutputMysql.getPort() == null ? Constants.DEFAULT_MYSQL_PORT : jaxbOutputMysql.getPort().getValue().intValue());
         outputRDBMSEntity.setJdbcDriver(jaxbOutputMysql.getJdbcDriver() == null ? null : jaxbOutputMysql.getJdbcDriver().getValue());
-        outputRDBMSEntity.setChunkSize(jaxbOutputMysql.getChunkSize() == null ? Constants.DEFAULT_CHUNKSIZE : jaxbOutputMysql.getChunkSize().getValue().intValue());
+        //outputRDBMSEntity.setChunkSize(jaxbOutputMysql.getChunkSize() == null ? Constants.DEFAULT_CHUNKSIZE : jaxbOutputMysql.getChunkSize().getValue().intValue());
         outputRDBMSEntity.setDatabaseType("Mysql");
 
         if (jaxbOutputMysql.getLoadType().getNewTable() != null)
@@ -102,6 +97,13 @@ public class OutputMysqlEntityGenerator extends OutputComponentGeneratorBase {
                 .extractRuntimeProperties(jaxbOutputMysql.getRuntimeProperties()));
 /*		outputRDBMSEntity.setRuntimeProperties(OutputEntityUtils
                 .extractRuntimeProperties(jaxbOutputMysql.getRuntimeProperties()));*/
+
+        /**New fields added since the project was open-sourced*/
+            //for batchsize which was named to chunksize since there is batch in the ETL tool as well
+        outputRDBMSEntity.setChunkSize(jaxbOutputMysql.getChunkSize()==null?null:jaxbOutputMysql.getChunkSize().getValue());
+            //extra url parameters has been
+        outputRDBMSEntity.setExtraUrlParamters(jaxbOutputMysql.getExtraUrlParams()==null?null:jaxbOutputMysql.getExtraUrlParams().getValue());
+         /**end**/
     }
 
     @Override

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/OutputOracleEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/OutputOracleEntityGenerator.java
@@ -21,12 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
-/**
- * The Class OutputOracleEntityGenerator.
- *
- * @author Bitwise
- *
- */
+
 public class OutputOracleEntityGenerator extends OutputComponentGeneratorBase {
 
     private static Logger LOG = LoggerFactory.getLogger(OutputOracleEntityGenerator.class);
@@ -88,6 +83,14 @@ public class OutputOracleEntityGenerator extends OutputComponentGeneratorBase {
         } else {
             outputRDBMSEntity.setSchemaName(null);
         }
+
+
+        /**New fields added since the project was open-sourced*/
+        //for batchsize which was named to chunksize since there is batch in the ETL tool as well
+        outputRDBMSEntity.setChunkSize(jaxbOutputOracle.getChunkSize()==null?null:jaxbOutputOracle.getChunkSize().getValue());
+        //extra url parameters has been
+        outputRDBMSEntity.setExtraUrlParamters(jaxbOutputOracle.getExtraUrlParams()==null?null:jaxbOutputOracle.getExtraUrlParams().getValue());
+        /**end**/
     }
 
     @Override

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/OutputTeradataEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/OutputTeradataEntityGenerator.java
@@ -23,12 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
-/**
- * The Class OutputTeradataEntityGenerator.
- *
- * @author Bitwise
- *
- */
+
 public class OutputTeradataEntityGenerator extends OutputComponentGeneratorBase {
 
     private Teradata jaxbOutputTeradata;
@@ -102,7 +97,13 @@ public class OutputTeradataEntityGenerator extends OutputComponentGeneratorBase 
         outputRDBMSEntity.setRuntimeProperties(jaxbOutputTeradata.getRuntimeProperties() == null ? new Properties() : OutputEntityUtils
                 .extractRuntimeProperties(jaxbOutputTeradata.getRuntimeProperties()));
 /*		outputRDBMSEntity.setRuntimeProperties(OutputEntityUtils
-                .extractRuntimeProperties(jaxbOutputMysql.getRuntimeProperties()));*/
+                .extractRuntimeProperties(jaxbOutputTeradata.getRuntimeProperties()));*/
+        /**New fields added since the project was open-sourced*/
+        //for batchsize which was named to chunksize since there is batch in the ETL tool as well
+        outputRDBMSEntity.setChunkSize(jaxbOutputTeradata.getChunkSize()==null?null:jaxbOutputTeradata.getChunkSize().getValue());
+        //extra url parameters has been
+        outputRDBMSEntity.setExtraUrlParamters(jaxbOutputTeradata.getExtraUrlParams()==null?null:jaxbOutputTeradata.getExtraUrlParams().getValue());
+        /**end**/
     }
 
     @Override

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/AggregateBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/AggregateBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
-import hydrograph.engine.jaxb.operationstypes.Aggregate;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
+import hydrograph.engine.jaxb.operationstypes.Aggregate;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
+
 /**
- * The Class ObjectFactory.
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.aggregate package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeOperation.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeOperation.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
-
-import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeOperationInputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeOperationInputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeOperationInputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeOperationInputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeOutSocketAsInSocketIn0.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeOutSocketAsInSocketIn0.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypePrimaryKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypePrimaryKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
 
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeSecondaryKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeSecondaryKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeSecondayKeyFieldsAttributes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeSecondayKeyFieldsAttributes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
-
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-import hydrograph.engine.jaxb.commontypes.TypeSortOrder;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
+import hydrograph.engine.jaxb.commontypes.TypeSortOrder;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeTransformExpression.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/aggregate/TypeTransformExpression.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.aggregate;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/clone/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/clone/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.clone;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.clone package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/clone/TypeCloneInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/clone/TypeCloneInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.clone;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/clone/TypeCloneOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/clone/TypeCloneOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.clone;
-
-import hydrograph.engine.jaxb.commontypes.TypeStraightPullOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/clone/TypeOutSocketAsInSocketIn0.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/clone/TypeOutSocketAsInSocketIn0.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.clone;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/FtpIn.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/FtpIn.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commandtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.TypeCommandComponent;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/Hplsql.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/Hplsql.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commandtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.TypeCommandComponent;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commandtypes;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.commandtypes package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {
@@ -28,12 +37,14 @@ public class ObjectFactory {
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: hydrograph.engine.jaxb.commandtypes
+     * 
      */
     public ObjectFactory() {
     }
 
     /**
      * Create an instance of {@link Hplsql }
+     * 
      */
     public Hplsql createHplsql() {
         return new Hplsql();
@@ -41,6 +52,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Hplsql.Execute }
+     * 
      */
     public Hplsql.Execute createHplsqlExecute() {
         return new Hplsql.Execute();
@@ -48,6 +60,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RunSQL }
+     * 
      */
     public RunSQL createRunSQL() {
         return new RunSQL();
@@ -55,6 +68,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RunProgram }
+     * 
      */
     public RunProgram createRunProgram() {
         return new RunProgram();
@@ -62,6 +76,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link FtpIn }
+     * 
      */
     public FtpIn createFtpIn() {
         return new FtpIn();
@@ -69,6 +84,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Subjob }
+     * 
      */
     public Subjob createSubjob() {
         return new Subjob();
@@ -76,6 +92,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Hplsql.Command }
+     * 
      */
     public Hplsql.Command createHplsqlCommand() {
         return new Hplsql.Command();
@@ -83,6 +100,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Hplsql.Execute.Query }
+     * 
      */
     public Hplsql.Execute.Query createHplsqlExecuteQuery() {
         return new Hplsql.Execute.Query();
@@ -90,6 +108,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Hplsql.Execute.Uri }
+     * 
      */
     public Hplsql.Execute.Uri createHplsqlExecuteUri() {
         return new Hplsql.Execute.Uri();
@@ -97,6 +116,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RunSQL.DatabaseConnectionName }
+     * 
      */
     public RunSQL.DatabaseConnectionName createRunSQLDatabaseConnectionName() {
         return new RunSQL.DatabaseConnectionName();
@@ -104,6 +124,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RunSQL.ServerName }
+     * 
      */
     public RunSQL.ServerName createRunSQLServerName() {
         return new RunSQL.ServerName();
@@ -111,6 +132,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RunSQL.PortNumber }
+     * 
      */
     public RunSQL.PortNumber createRunSQLPortNumber() {
         return new RunSQL.PortNumber();
@@ -118,6 +140,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RunSQL.DatabaseName }
+     * 
      */
     public RunSQL.DatabaseName createRunSQLDatabaseName() {
         return new RunSQL.DatabaseName();
@@ -125,6 +148,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RunSQL.DbUserName }
+     * 
      */
     public RunSQL.DbUserName createRunSQLDbUserName() {
         return new RunSQL.DbUserName();
@@ -132,6 +156,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RunSQL.DbPassword }
+     * 
      */
     public RunSQL.DbPassword createRunSQLDbPassword() {
         return new RunSQL.DbPassword();
@@ -139,6 +164,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RunSQL.QueryCommand }
+     * 
      */
     public RunSQL.QueryCommand createRunSQLQueryCommand() {
         return new RunSQL.QueryCommand();
@@ -146,6 +172,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RunProgram.Command }
+     * 
      */
     public RunProgram.Command createRunProgramCommand() {
         return new RunProgram.Command();
@@ -153,6 +180,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link FtpIn.Host }
+     * 
      */
     public FtpIn.Host createFtpInHost() {
         return new FtpIn.Host();
@@ -160,6 +188,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Subjob.Path }
+     * 
      */
     public Subjob.Path createSubjobPath() {
         return new Subjob.Path();

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/RunProgram.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/RunProgram.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commandtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.TypeCommandComponent;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/RunSQL.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/RunSQL.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commandtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.TypeCommandComponent;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/Subjob.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commandtypes/Subjob.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,15 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commandtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.TypeCommandComponent;
 import hydrograph.engine.jaxb.commontypes.TypeProperties;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/BooleanValueType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/BooleanValueType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/ElementValueIntegerType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/ElementValueIntegerType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,16 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.math.BigInteger;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
-import java.math.BigInteger;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/ElementValueStringType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/ElementValueStringType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/FieldDataTypes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/FieldDataTypes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/KeepValue.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/KeepValue.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/KeyfieldDescriptionType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/KeyfieldDescriptionType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/MatchValue.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/MatchValue.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.commontypes package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {
@@ -28,12 +37,14 @@ public class ObjectFactory {
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: hydrograph.engine.jaxb.commontypes
+     * 
      */
     public ObjectFactory() {
     }
 
     /**
      * Create an instance of {@link TypeUnknownComponent }
+     * 
      */
     public TypeUnknownComponent createTypeUnknownComponent() {
         return new TypeUnknownComponent();
@@ -41,6 +52,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link KeyfieldDescriptionType }
+     * 
      */
     public KeyfieldDescriptionType createKeyfieldDescriptionType() {
         return new KeyfieldDescriptionType();
@@ -48,6 +60,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link KeyfieldDescriptionType.KeyFields }
+     * 
      */
     public KeyfieldDescriptionType.KeyFields createKeyfieldDescriptionTypeKeyFields() {
         return new KeyfieldDescriptionType.KeyFields();
@@ -55,6 +68,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeProperties }
+     * 
      */
     public TypeProperties createTypeProperties() {
         return new TypeProperties();
@@ -62,6 +76,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeInputField }
+     * 
      */
     public TypeInputField createTypeInputField() {
         return new TypeInputField();
@@ -69,6 +84,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeFieldName }
+     * 
      */
     public TypeFieldName createTypeFieldName() {
         return new TypeFieldName();
@@ -76,6 +92,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOutputInSocket }
+     * 
      */
     public TypeOutputInSocket createTypeOutputInSocket() {
         return new TypeOutputInSocket();
@@ -83,6 +100,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOperationOutputFields }
+     * 
      */
     public TypeOperationOutputFields createTypeOperationOutputFields() {
         return new TypeOperationOutputFields();
@@ -90,6 +108,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeBaseField }
+     * 
      */
     public TypeBaseField createTypeBaseField() {
         return new TypeBaseField();
@@ -97,6 +116,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeInputOutSocket }
+     * 
      */
     public TypeInputOutSocket createTypeInputOutSocket() {
         return new TypeInputOutSocket();
@@ -104,6 +124,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeBaseRecord }
+     * 
      */
     public TypeBaseRecord createTypeBaseRecord() {
         return new TypeBaseRecord();
@@ -111,6 +132,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeBaseInSocket }
+     * 
      */
     public TypeBaseInSocket createTypeBaseInSocket() {
         return new TypeBaseInSocket();
@@ -118,6 +140,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link ElementValueStringType }
+     * 
      */
     public ElementValueStringType createElementValueStringType() {
         return new ElementValueStringType();
@@ -125,6 +148,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeExternalSchema }
+     * 
      */
     public TypeExternalSchema createTypeExternalSchema() {
         return new TypeExternalSchema();
@@ -132,6 +156,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOperationInputFields }
+     * 
      */
     public TypeOperationInputFields createTypeOperationInputFields() {
         return new TypeOperationInputFields();
@@ -139,6 +164,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link BooleanValueType }
+     * 
      */
     public BooleanValueType createBooleanValueType() {
         return new BooleanValueType();
@@ -146,6 +172,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeTransformOperation }
+     * 
      */
     public TypeTransformOperation createTypeTransformOperation() {
         return new TypeTransformOperation();
@@ -153,6 +180,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link ElementValueIntegerType }
+     * 
      */
     public ElementValueIntegerType createElementValueIntegerType() {
         return new ElementValueIntegerType();
@@ -160,6 +188,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeBaseComponent }
+     * 
      */
     public TypeBaseComponent createTypeBaseComponent() {
         return new TypeBaseComponent();
@@ -167,6 +196,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeExpressionOutputFields }
+     * 
      */
     public TypeExpressionOutputFields createTypeExpressionOutputFields() {
         return new TypeExpressionOutputFields();
@@ -174,6 +204,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeKeyFields }
+     * 
      */
     public TypeKeyFields createTypeKeyFields() {
         return new TypeKeyFields();
@@ -181,6 +212,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOutputRecordCount }
+     * 
      */
     public TypeOutputRecordCount createTypeOutputRecordCount() {
         return new TypeOutputRecordCount();
@@ -188,6 +220,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeBaseInSocketFixedIn0 }
+     * 
      */
     public TypeBaseInSocketFixedIn0 createTypeBaseInSocketFixedIn0() {
         return new TypeBaseInSocketFixedIn0();
@@ -195,6 +228,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeStraightPullOutSocket }
+     * 
      */
     public TypeStraightPullOutSocket createTypeStraightPullOutSocket() {
         return new TypeStraightPullOutSocket();
@@ -202,6 +236,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeTrueFalse }
+     * 
      */
     public TypeTrueFalse createTypeTrueFalse() {
         return new TypeTrueFalse();
@@ -209,6 +244,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeMapField }
+     * 
      */
     public TypeMapField createTypeMapField() {
         return new TypeMapField();
@@ -216,6 +252,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeExpressionField }
+     * 
      */
     public TypeExpressionField createTypeExpressionField() {
         return new TypeExpressionField();
@@ -223,6 +260,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOutSocketAsInSocket }
+     * 
      */
     public TypeOutSocketAsInSocket createTypeOutSocketAsInSocket() {
         return new TypeOutSocketAsInSocket();
@@ -230,6 +268,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeBaseOutSocket }
+     * 
      */
     public TypeBaseOutSocket createTypeBaseOutSocket() {
         return new TypeBaseOutSocket();
@@ -237,6 +276,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOperationsOutSocket }
+     * 
      */
     public TypeOperationsOutSocket createTypeOperationsOutSocket() {
         return new TypeOperationsOutSocket();
@@ -244,6 +284,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeTransformExpression }
+     * 
      */
     public TypeTransformExpression createTypeTransformExpression() {
         return new TypeTransformExpression();
@@ -251,6 +292,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOperationField }
+     * 
      */
     public TypeOperationField createTypeOperationField() {
         return new TypeOperationField();
@@ -258,6 +300,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeUnknownComponent.Properties }
+     * 
      */
     public TypeUnknownComponent.Properties createTypeUnknownComponentProperties() {
         return new TypeUnknownComponent.Properties();
@@ -265,6 +308,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link KeyfieldDescriptionType.KeyFields.Field }
+     * 
      */
     public KeyfieldDescriptionType.KeyFields.Field createKeyfieldDescriptionTypeKeyFieldsField() {
         return new KeyfieldDescriptionType.KeyFields.Field();
@@ -272,6 +316,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeProperties.Property }
+     * 
      */
     public TypeProperties.Property createTypePropertiesProperty() {
         return new TypeProperties.Property();

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/ScaleTypeList.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/ScaleTypeList.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/StandardCharsets.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/StandardCharsets.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TrueFalse.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TrueFalse.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseComponent.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseComponent.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,12 +9,16 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
-import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,11 +9,20 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyAttribute;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 import hydrograph.engine.jaxb.exceltype.TypeExcelField;
 import hydrograph.engine.jaxb.generatesequence.TypeNameField;
 import hydrograph.engine.jaxb.igr.TypeGenerateRecordField;
@@ -23,11 +32,6 @@ import hydrograph.engine.jaxb.ooracle.TypeOracleField;
 import hydrograph.engine.jaxb.oredshift.TypeRedshiftField;
 import hydrograph.engine.jaxb.osparkredshift.TypeSparkredshiftField;
 import hydrograph.engine.jaxb.oteradata.TypeTeradataField;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
-import java.util.HashMap;
-import java.util.Map;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,22 +9,26 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyAttribute;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 import hydrograph.engine.jaxb.clone.TypeCloneInSocket;
 import hydrograph.engine.jaxb.executiontracking.TypeExecutiontrackingInSocket;
 import hydrograph.engine.jaxb.filter.TypeFilterInSocket;
 import hydrograph.engine.jaxb.limit.TypeLimitInSocket;
 import hydrograph.engine.jaxb.partitionbyexpression.TypePbeInSocket;
 import hydrograph.engine.jaxb.transform.TypeTransformInSocket;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
-import java.util.HashMap;
-import java.util.Map;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseInSocketFixedIn0.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseInSocketFixedIn0.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,15 +9,20 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.HashMap;
 import java.util.Map;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyAttribute;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeBaseRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,11 +9,20 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.exceltype.TypeExcelRecord;
 import hydrograph.engine.jaxb.igr.TypeGenerateRecordRecord;
 import hydrograph.engine.jaxb.ojdbcupdate.TypeJdbcupdateRecord;
@@ -22,10 +31,6 @@ import hydrograph.engine.jaxb.ooracle.TypeOracleRecord;
 import hydrograph.engine.jaxb.oredshift.TypeRedshiftRecord;
 import hydrograph.engine.jaxb.osparkredshift.TypeSparkredshiftRecord;
 import hydrograph.engine.jaxb.oteradata.TypeTeradataRecord;
-
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeCommandComponent.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeCommandComponent.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,20 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
-
-import hydrograph.engine.jaxb.commandtypes.*;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commandtypes.FtpIn;
+import hydrograph.engine.jaxb.commandtypes.Hplsql;
+import hydrograph.engine.jaxb.commandtypes.RunProgram;
+import hydrograph.engine.jaxb.commandtypes.RunSQL;
+import hydrograph.engine.jaxb.commandtypes.Subjob;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeExpressionField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeExpressionField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeExpressionOutputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeExpressionOutputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeExternalSchema.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeExternalSchema.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeFieldName.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeFieldName.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.sort.TypePrimaryKeyFieldsAttributes;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeInputComponent.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeInputComponent.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,11 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.exceltype.TypeFileExcelBase;
 import hydrograph.engine.jaxb.ifmixedscheme.TypeMixedBase;
 import hydrograph.engine.jaxb.ifsubjob.TypeInputFileDelimitedSubjob;
@@ -27,10 +34,6 @@ import hydrograph.engine.jaxb.isparkredshift.TypeInputSparkredshiftBase;
 import hydrograph.engine.jaxb.iteradata.TypeInputTeradataBase;
 import hydrograph.engine.jaxb.itffw.TypeFixedWidthBase;
 import hydrograph.engine.jaxb.itfs.TypeInputFileSequenceBase;
-
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeInputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeInputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,21 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.executiontracking.TypeExecutiontrackingOperationInputField;
 import hydrograph.engine.jaxb.filter.TypeFilterOperationInputField;
 import hydrograph.engine.jaxb.generatesequence.TypePassthroughInputField;
 import hydrograph.engine.jaxb.partitionbyexpression.TypePbeOperationInputField;
 import hydrograph.engine.jaxb.transform.TypeTransformOperationInputField;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeInputOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeInputOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,11 +9,16 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.exceltype.TypeExcelOutSocket;
 import hydrograph.engine.jaxb.ifmixedscheme.TypeInputMixedOutSocket;
 import hydrograph.engine.jaxb.ifxml.TypeInputXmlOutSocket;
@@ -24,8 +29,6 @@ import hydrograph.engine.jaxb.ioracle.TypeInputOracleOutSocket;
 import hydrograph.engine.jaxb.iteradata.TypeInputTeradataOutSocket;
 import hydrograph.engine.jaxb.itffw.TypeInputFixedwidthOutSocket;
 import hydrograph.engine.jaxb.itfs.TypeInputSequenceOutSocket;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,16 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeLookupInsocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeLookupInsocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeMapField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeMapField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOperationField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOperationField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOperationInputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOperationInputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,22 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.executiontracking.TypeExecutiontrackingOperationInputFields;
 import hydrograph.engine.jaxb.filter.TypeFilterOperationInputFields;
 import hydrograph.engine.jaxb.partitionbyexpression.TypePbeInputFields;
 import hydrograph.engine.jaxb.transform.TypeTransformOperationInputFields;
-
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOperationOutputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOperationOutputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
-import hydrograph.engine.jaxb.generatesequence.TypeOperationOutputField;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.generatesequence.TypeOperationOutputField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOperationsComponent.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOperationsComponent.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,23 +9,31 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.aggregate.AggregateBase;
 import hydrograph.engine.jaxb.cumulate.CumulateBase;
 import hydrograph.engine.jaxb.groupcombine.GroupcombineBase;
 import hydrograph.engine.jaxb.join.JoinBase;
 import hydrograph.engine.jaxb.lookup.LookupBase;
-import hydrograph.engine.jaxb.operationstypes.*;
+import hydrograph.engine.jaxb.operationstypes.Executiontracking;
+import hydrograph.engine.jaxb.operationstypes.Filter;
+import hydrograph.engine.jaxb.operationstypes.GenerateSequence;
+import hydrograph.engine.jaxb.operationstypes.Normalize;
+import hydrograph.engine.jaxb.operationstypes.Transform;
 import hydrograph.engine.jaxb.partitionbyexpression.PartitionByExpressionBase;
 import hydrograph.engine.jaxb.subjob.SubjobBase;
-
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOperationsOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOperationsOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,23 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.executiontracking.TypeExecutiontrackingOutSocket;
 import hydrograph.engine.jaxb.filter.TypeFilterOutSocket;
 import hydrograph.engine.jaxb.partitionbyexpression.TypePbeOutSocket;
 import hydrograph.engine.jaxb.transform.TypeTransformOutSocket;
-
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOutSocketAsInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOutSocketAsInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,15 +9,20 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.HashMap;
 import java.util.Map;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyAttribute;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOutputComponent.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOutputComponent.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,11 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.ofmixedscheme.TypeMixedBase;
 import hydrograph.engine.jaxb.ofsubjob.TypeOutputFileDelimitedSubjob;
 import hydrograph.engine.jaxb.ofxml.TypeOutputFileXmlBase;
@@ -27,10 +34,6 @@ import hydrograph.engine.jaxb.oteradata.TypeOutputTeradataBase;
 import hydrograph.engine.jaxb.otffw.TypeFixedWidthBase;
 import hydrograph.engine.jaxb.otfs.TypeOutputFileSequenceBase;
 import hydrograph.engine.jaxb.outputtypes.Discard;
-
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOutputInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOutputInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,11 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.ofmixedscheme.TypeOutputMixedInSocket;
 import hydrograph.engine.jaxb.ofxml.TypeOutputXmlInSocket;
 import hydrograph.engine.jaxb.ohivetextfile.TypeOutputHiveTextFileDelimitedInSocket;
@@ -26,11 +30,6 @@ import hydrograph.engine.jaxb.otdiscard.TypeOutputInSocketIno;
 import hydrograph.engine.jaxb.oteradata.TypeOutputTeradataOutSocket;
 import hydrograph.engine.jaxb.otffw.TypeOutputFixedwidthInSocket;
 import hydrograph.engine.jaxb.otfs.TypeOutputSequenceInSocket;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOutputRecordCount.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeOutputRecordCount.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeProperties.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeProperties.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeSortOrder.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeSortOrder.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeStraightPullComponent.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeStraightPullComponent.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,20 +9,23 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.limit.TypeLimitBase;
 import hydrograph.engine.jaxb.removedups.TypeRemovedupsBase;
 import hydrograph.engine.jaxb.sort.TypeSortBase;
 import hydrograph.engine.jaxb.straightpulltypes.Clone;
 import hydrograph.engine.jaxb.straightpulltypes.UnionAll;
-
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeStraightPullOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeStraightPullOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,15 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.clone.TypeCloneOutSocket;
 import hydrograph.engine.jaxb.limit.TypeLimitOutSocket;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeTransformExpression.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeTransformExpression.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,15 +9,20 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.HashMap;
 import java.util.Map;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyAttribute;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeTransformOperation.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeTransformOperation.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,23 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyAttribute;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 import hydrograph.engine.jaxb.executiontracking.TypeExecutiontrackingOperation;
 import hydrograph.engine.jaxb.filter.TypeFilterOperation;
 import hydrograph.engine.jaxb.partitionbyexpression.TypePbeOperation;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
-import java.util.HashMap;
-import java.util.Map;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeTrueFalse.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeTrueFalse.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeUnknownComponent.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/commontypes/TypeUnknownComponent.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.commontypes;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/CumulateBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/CumulateBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
-import hydrograph.engine.jaxb.operationstypes.Cumulate;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
+import hydrograph.engine.jaxb.operationstypes.Cumulate;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
+
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.cumulate package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {
@@ -27,12 +37,14 @@ public class ObjectFactory {
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: hydrograph.engine.jaxb.cumulate
+     * 
      */
     public ObjectFactory() {
     }
 
     /**
      * Create an instance of {@link TypeSecondaryKeyFields }
+     * 
      */
     public TypeSecondaryKeyFields createTypeSecondaryKeyFields() {
         return new TypeSecondaryKeyFields();
@@ -40,6 +52,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOperation }
+     * 
      */
     public TypeOperation createTypeOperation() {
         return new TypeOperation();
@@ -47,6 +60,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOutSocket }
+     * 
      */
     public TypeOutSocket createTypeOutSocket() {
         return new TypeOutSocket();
@@ -54,6 +68,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOperationInputFields }
+     * 
      */
     public TypeOperationInputFields createTypeOperationInputFields() {
         return new TypeOperationInputFields();
@@ -61,6 +76,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeInSocket }
+     * 
      */
     public TypeInSocket createTypeInSocket() {
         return new TypeInSocket();
@@ -68,6 +84,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeTransformExpression }
+     * 
      */
     public TypeTransformExpression createTypeTransformExpression() {
         return new TypeTransformExpression();
@@ -75,6 +92,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeOperationInputField }
+     * 
      */
     public TypeOperationInputField createTypeOperationInputField() {
         return new TypeOperationInputField();
@@ -82,6 +100,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypeSecondayKeyFieldsAttributes }
+     * 
      */
     public TypeSecondayKeyFieldsAttributes createTypeSecondayKeyFieldsAttributes() {
         return new TypeSecondayKeyFieldsAttributes();
@@ -89,6 +108,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TypePrimaryKeyFields }
+     * 
      */
     public TypePrimaryKeyFields createTypePrimaryKeyFields() {
         return new TypePrimaryKeyFields();
@@ -96,6 +116,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link CumulateBase }
+     * 
      */
     public CumulateBase createCumulateBase() {
         return new CumulateBase();

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeOperation.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeOperation.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
-
-import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeOperationInputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeOperationInputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeOperationInputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeOperationInputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypePrimaryKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypePrimaryKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
 
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeSecondaryKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeSecondaryKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeSecondayKeyFieldsAttributes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeSecondayKeyFieldsAttributes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
-
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-import hydrograph.engine.jaxb.commontypes.TypeSortOrder;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
+import hydrograph.engine.jaxb.commontypes.TypeSortOrder;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeTransformExpression.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/cumulate/TypeTransformExpression.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.cumulate;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/exceltype/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/exceltype/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.exceltype;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.exceltype package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/exceltype/TypeExcelField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/exceltype/TypeExcelField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.exceltype;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/exceltype/TypeExcelOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/exceltype/TypeExcelOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.exceltype;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/exceltype/TypeExcelRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/exceltype/TypeExcelRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.exceltype;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/exceltype/TypeFileExcelBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/exceltype/TypeFileExcelBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.exceltype;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.outputtypes.ExcelFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.outputtypes.ExcelFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.executiontracking;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
 
-
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.executiontracking package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeExecutiontrackingInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeExecutiontrackingInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.executiontracking;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeExecutiontrackingOperation.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeExecutiontrackingOperation.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.executiontracking;
-
-import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeExecutiontrackingOperationInputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeExecutiontrackingOperationInputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.executiontracking;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeExecutiontrackingOperationInputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeExecutiontrackingOperationInputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.executiontracking;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationInputFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationInputFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeExecutiontrackingOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeExecutiontrackingOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.executiontracking;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeOutSocketAsInSocketIn0.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypeOutSocketAsInSocketIn0.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.executiontracking;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypesOutSocketTypes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/executiontracking/TypesOutSocketTypes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.executiontracking;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.filter;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.filter package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeFilterInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeFilterInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.filter;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeFilterOperation.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeFilterOperation.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.filter;
-
-import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeFilterOperationInputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeFilterOperationInputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.filter;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeFilterOperationInputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeFilterOperationInputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.filter;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationInputFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationInputFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeFilterOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeFilterOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.filter;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeOutSocketAsInSocketIn0.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypeOutSocketAsInSocketIn0.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.filter;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypesOutSocketTypes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/filter/TypesOutSocketTypes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.filter;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.generatesequence;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
 
-
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.generatesequence package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/TypeNameField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/TypeNameField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.generatesequence;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/TypeOperation.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/TypeOperation.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.generatesequence;
-
-import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/TypeOperationOutputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/TypeOperationOutputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.generatesequence;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationOutputFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationOutputFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.generatesequence;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/TypePassthroughInputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/generatesequence/TypePassthroughInputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.generatesequence;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/GroupcombineBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/GroupcombineBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
-import hydrograph.engine.jaxb.operationstypes.Groupcombine;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
+import hydrograph.engine.jaxb.operationstypes.Groupcombine;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.groupcombine package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeOperation.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeOperation.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
-
-import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeOperationInputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeOperationInputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeOperationInputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeOperationInputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeOutSocketAsInSocketIn0.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeOutSocketAsInSocketIn0.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypePrimaryKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypePrimaryKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
 
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeSecondaryKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeSecondaryKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeSecondayKeyFieldsAttributes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeSecondayKeyFieldsAttributes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeTransformExpression.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/groupcombine/TypeTransformExpression.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.groupcombine;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifmixedscheme/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifmixedscheme/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifmixedscheme;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
 
-
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ifmixedscheme package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifmixedscheme/TypeInputMixedOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifmixedscheme/TypeInputMixedOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifmixedscheme;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifmixedscheme/TypeMixedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifmixedscheme/TypeMixedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifmixedscheme;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.TextFileMixedScheme;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.TextFileMixedScheme;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifmixedscheme/TypeMixedField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifmixedscheme/TypeMixedField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifmixedscheme;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifmixedscheme/TypeMixedRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifmixedscheme/TypeMixedRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifmixedscheme;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifparquet/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifparquet/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifparquet;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
 
-
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ifparquet package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifparquet/TypeInputDelimitedOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifparquet/TypeInputDelimitedOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifparquet;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifparquet/TypeInputFileDelimitedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifparquet/TypeInputFileDelimitedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifparquet;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.ParquetFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.ParquetFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifsubjob/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifsubjob/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifsubjob;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
 
-
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ifsubjob package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifsubjob/TypeInputDelimitedOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifsubjob/TypeInputDelimitedOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifsubjob;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifsubjob/TypeInputFileDelimitedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifsubjob/TypeInputFileDelimitedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifsubjob;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.Subjob;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.Subjob;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifsubjob/TypeInputFileDelimitedSubjob.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifsubjob/TypeInputFileDelimitedSubjob.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifsubjob;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.SubjobInput;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.SubjobInput;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifxml/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifxml/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifxml;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
 
-
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ifxml package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifxml/TypeInputFileXmlBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifxml/TypeInputFileXmlBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifxml;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.XmlFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.XmlFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifxml/TypeInputXmlOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifxml/TypeInputXmlOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifxml;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifxml/TypeXmlField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifxml/TypeXmlField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifxml;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifxml/TypeXmlRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ifxml/TypeXmlRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ifxml;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/igr/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/igr/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.igr;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.igr package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/igr/TypeGenerateRecordBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/igr/TypeGenerateRecordBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.igr;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.GenerateRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.GenerateRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/igr/TypeGenerateRecordField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/igr/TypeGenerateRecordField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.igr;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/igr/TypeGenerateRecordOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/igr/TypeGenerateRecordOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.igr;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/igr/TypeGenerateRecordRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/igr/TypeGenerateRecordRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.igr;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/FieldBasicType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/FieldBasicType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/HivePartitionFieldsType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/HivePartitionFieldsType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/HivePartitionFilterType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/HivePartitionFilterType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihiveparquet;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/HivePathType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/HivePathType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/HiveType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/HiveType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihiveparquet;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ihiveparquet package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/PartitionColumn.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/PartitionColumn.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/PartitionFieldBasicType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/PartitionFieldBasicType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/TypeInputDelimitedOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/TypeInputDelimitedOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihiveparquet;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/TypeInputFileDelimitedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihiveparquet/TypeInputFileDelimitedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihiveparquet;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.ParquetHiveFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.ParquetHiveFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/FieldBasicType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/FieldBasicType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/HivePartitionFieldsType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/HivePartitionFieldsType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/HivePartitionFilterType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/HivePartitionFilterType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihivetextfile;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/HivePathType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/HivePathType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/HiveType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/HiveType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihivetextfile;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
+
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ihivetextfile package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/PartitionColumn.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/PartitionColumn.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/PartitionFieldBasicType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/PartitionFieldBasicType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/TypeInputHiveTextDelimitedOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/TypeInputHiveTextDelimitedOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihivetextfile;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/TypeInputHiveTextFileDelimitedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ihivetextfile/TypeInputHiveTextFileDelimitedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ihivetextfile;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.HiveTextFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.HiveTextFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/imysql/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/imysql/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.imysql;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.imysql package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {
@@ -39,6 +48,14 @@ public class ObjectFactory {
      */
     public TypeInputMysqlBase createTypeInputMysqlBase() {
         return new TypeInputMysqlBase();
+    }
+
+    /**
+     * Create an instance of {@link TypePartitionsChoice }
+     * 
+     */
+    public TypePartitionsChoice createTypePartitionsChoice() {
+        return new TypePartitionsChoice();
     }
 
     /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/imysql/TypeInputMysqlBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/imysql/TypeInputMysqlBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.imysql;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.Mysql;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.Mysql;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/imysql/TypeInputMysqlOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/imysql/TypeInputMysqlOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.imysql;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/imysql/TypePartitionsChoice.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/imysql/TypePartitionsChoice.java
@@ -1,0 +1,162 @@
+
+/*****************************************************************************************
+ * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ ****************************************************************************************/
+
+package hydrograph.engine.jaxb.imysql;
+
+import java.math.BigInteger;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+
+
+/**
+ * <p>Java class for type-partitions-choice complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="type-partitions-choice">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="lowerBound" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type"/>
+ *         &lt;element name="upperBound" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type"/>
+ *         &lt;element name="columnName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
+ *       &lt;/sequence>
+ *       &lt;attribute name="value" use="required" type="{http://www.w3.org/2001/XMLSchema}integer" />
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "type-partitions-choice", namespace = "hydrograph/engine/jaxb/imysql", propOrder = {
+    "lowerBound",
+    "upperBound",
+    "columnName"
+})
+public class TypePartitionsChoice {
+
+    @XmlElement(required = true)
+    protected ElementValueIntegerType lowerBound;
+    @XmlElement(required = true)
+    protected ElementValueIntegerType upperBound;
+    @XmlElement(required = true)
+    protected ElementValueStringType columnName;
+    @XmlAttribute(name = "value", required = true)
+    protected BigInteger value;
+
+    /**
+     * Gets the value of the lowerBound property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public ElementValueIntegerType getLowerBound() {
+        return lowerBound;
+    }
+
+    /**
+     * Sets the value of the lowerBound property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public void setLowerBound(ElementValueIntegerType value) {
+        this.lowerBound = value;
+    }
+
+    /**
+     * Gets the value of the upperBound property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public ElementValueIntegerType getUpperBound() {
+        return upperBound;
+    }
+
+    /**
+     * Sets the value of the upperBound property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public void setUpperBound(ElementValueIntegerType value) {
+        this.upperBound = value;
+    }
+
+    /**
+     * Gets the value of the columnName property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getColumnName() {
+        return columnName;
+    }
+
+    /**
+     * Sets the value of the columnName property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setColumnName(ElementValueStringType value) {
+        this.columnName = value;
+    }
+
+    /**
+     * Gets the value of the value property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link BigInteger }
+     *     
+     */
+    public BigInteger getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the value of the value property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link BigInteger }
+     *     
+     */
+    public void setValue(BigInteger value) {
+        this.value = value;
+    }
+
+}

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/AvroFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/AvroFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.itfd.TypeInputFileDelimitedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/GenerateRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/GenerateRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.igr.TypeGenerateRecordBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/HiveTextFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/HiveTextFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,15 +9,22 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.BooleanValueType;
-import hydrograph.engine.jaxb.ihivetextfile.*;
-
-import javax.xml.bind.annotation.*;
+import hydrograph.engine.jaxb.ihivetextfile.HivePartitionFieldsType;
+import hydrograph.engine.jaxb.ihivetextfile.HivePartitionFilterType;
+import hydrograph.engine.jaxb.ihivetextfile.HivePathType;
+import hydrograph.engine.jaxb.ihivetextfile.HiveType;
+import hydrograph.engine.jaxb.ihivetextfile.TypeInputHiveTextFileDelimitedBase;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Mysql.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Mysql.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.imysql.TypeInputMysqlBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.imysql.TypeInputMysqlBase;
+import hydrograph.engine.jaxb.imysql.TypePartitionsChoice;
 
 
 /**
@@ -38,6 +38,9 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="hostName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="port" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type" minOccurs="0"/>
  *         &lt;element name="jdbcDriver" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
+ *         &lt;element name="numPartitions" type="{hydrograph/engine/jaxb/imysql}type-partitions-choice" minOccurs="0"/>
+ *         &lt;element name="fetchSize" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
+ *         &lt;element name="extraUrlParams" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
  *         &lt;choice>
  *           &lt;element name="tableName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *           &lt;sequence>
@@ -61,6 +64,9 @@ import javax.xml.bind.annotation.XmlType;
     "hostName",
     "port",
     "jdbcDriver",
+    "numPartitions",
+    "fetchSize",
+    "extraUrlParams",
     "tableName",
     "selectQuery",
     "countQuery",
@@ -78,6 +84,9 @@ public class Mysql
     protected ElementValueIntegerType port;
     @XmlElement(required = true)
     protected ElementValueStringType jdbcDriver;
+    protected TypePartitionsChoice numPartitions;
+    protected ElementValueStringType fetchSize;
+    protected ElementValueStringType extraUrlParams;
     protected ElementValueStringType tableName;
     protected ElementValueStringType selectQuery;
     protected ElementValueStringType countQuery;
@@ -180,6 +189,78 @@ public class Mysql
      */
     public void setJdbcDriver(ElementValueStringType value) {
         this.jdbcDriver = value;
+    }
+
+    /**
+     * Gets the value of the numPartitions property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TypePartitionsChoice }
+     *     
+     */
+    public TypePartitionsChoice getNumPartitions() {
+        return numPartitions;
+    }
+
+    /**
+     * Sets the value of the numPartitions property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TypePartitionsChoice }
+     *     
+     */
+    public void setNumPartitions(TypePartitionsChoice value) {
+        this.numPartitions = value;
+    }
+
+    /**
+     * Gets the value of the fetchSize property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getFetchSize() {
+        return fetchSize;
+    }
+
+    /**
+     * Sets the value of the fetchSize property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setFetchSize(ElementValueStringType value) {
+        this.fetchSize = value;
+    }
+
+    /**
+     * Gets the value of the extraUrlParams property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getExtraUrlParams() {
+        return extraUrlParams;
+    }
+
+    /**
+     * Sets the value of the extraUrlParams property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setExtraUrlParams(ElementValueStringType value) {
+        this.extraUrlParams = value;
     }
 
     /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
 import javax.xml.bind.annotation.XmlRegistry;
+
+
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.inputtypes package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Oracle.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Oracle.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.ioracle.TypeInputOracleBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.ioracle.TypeInputOracleBase;
+import hydrograph.engine.jaxb.ioracle.TypePartitionsChoice;
 
 
 /**
@@ -38,6 +38,9 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="hostName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="port" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type" minOccurs="0"/>
  *         &lt;element name="driverType" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
+ *         &lt;element name="numPartitions" type="{hydrograph/engine/jaxb/ioracle}type-partitions-choice" minOccurs="0"/>
+ *         &lt;element name="fetchSize" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
+ *         &lt;element name="extraUrlParams" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
  *         &lt;element name="userName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="password" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="schemaName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
@@ -62,6 +65,9 @@ import javax.xml.bind.annotation.XmlType;
     "hostName",
     "port",
     "driverType",
+    "numPartitions",
+    "fetchSize",
+    "extraUrlParams",
     "userName",
     "password",
     "schemaName",
@@ -80,6 +86,9 @@ public class Oracle
     protected ElementValueIntegerType port;
     @XmlElement(required = true)
     protected ElementValueStringType driverType;
+    protected TypePartitionsChoice numPartitions;
+    protected ElementValueStringType fetchSize;
+    protected ElementValueStringType extraUrlParams;
     @XmlElement(required = true)
     protected ElementValueStringType userName;
     @XmlElement(required = true)
@@ -183,6 +192,78 @@ public class Oracle
      */
     public void setDriverType(ElementValueStringType value) {
         this.driverType = value;
+    }
+
+    /**
+     * Gets the value of the numPartitions property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TypePartitionsChoice }
+     *     
+     */
+    public TypePartitionsChoice getNumPartitions() {
+        return numPartitions;
+    }
+
+    /**
+     * Sets the value of the numPartitions property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TypePartitionsChoice }
+     *     
+     */
+    public void setNumPartitions(TypePartitionsChoice value) {
+        this.numPartitions = value;
+    }
+
+    /**
+     * Gets the value of the fetchSize property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getFetchSize() {
+        return fetchSize;
+    }
+
+    /**
+     * Sets the value of the fetchSize property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setFetchSize(ElementValueStringType value) {
+        this.fetchSize = value;
+    }
+
+    /**
+     * Gets the value of the extraUrlParams property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getExtraUrlParams() {
+        return extraUrlParams;
+    }
+
+    /**
+     * Sets the value of the extraUrlParams property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setExtraUrlParams(ElementValueStringType value) {
+        this.extraUrlParams = value;
     }
 
     /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/ParquetFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/ParquetFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.ifparquet.TypeInputFileDelimitedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/ParquetHiveFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/ParquetHiveFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,20 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
-
-import hydrograph.engine.jaxb.ihiveparquet.*;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.ihiveparquet.HivePartitionFieldsType;
+import hydrograph.engine.jaxb.ihiveparquet.HivePartitionFilterType;
+import hydrograph.engine.jaxb.ihiveparquet.HivePathType;
+import hydrograph.engine.jaxb.ihiveparquet.HiveType;
+import hydrograph.engine.jaxb.ihiveparquet.TypeInputFileDelimitedBase;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Redshift.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Redshift.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.iredshift.TypeInputRedshiftBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.iredshift.TypeInputRedshiftBase;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/SequenceInputFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/SequenceInputFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.itfs.TypeInputFileSequenceBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Sparkredshift.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Sparkredshift.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.isparkredshift.TypeInputSparkredshiftBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.isparkredshift.TypeInputSparkredshiftBase;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Subjob.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Subjob.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,15 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.TypeProperties;
 import hydrograph.engine.jaxb.ifsubjob.TypeInputFileDelimitedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/SubjobInput.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/SubjobInput.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
-
-import hydrograph.engine.jaxb.ifsubjob.TypeInputFileDelimitedSubjob;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.ifsubjob.TypeInputFileDelimitedSubjob;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Teradata.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/Teradata.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.iteradata.TypeInputTeradataBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.iteradata.TypeInputTeradataBase;
+import hydrograph.engine.jaxb.iteradata.TypePartitionsChoice;
 
 
 /**
@@ -38,6 +38,9 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="hostName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="port" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type"/>
  *         &lt;element name="jdbcDriver" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
+ *         &lt;element name="numPartitions" type="{hydrograph/engine/jaxb/iteradata}type-partitions-choice" minOccurs="0"/>
+ *         &lt;element name="fetchSize" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
+ *         &lt;element name="extraUrlParams" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
  *         &lt;choice>
  *           &lt;element name="tableName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
  *           &lt;sequence>
@@ -62,6 +65,9 @@ import javax.xml.bind.annotation.XmlType;
     "hostName",
     "port",
     "jdbcDriver",
+    "numPartitions",
+    "fetchSize",
+    "extraUrlParams",
     "tableName",
     "selectQuery",
     "countQuery",
@@ -81,6 +87,9 @@ public class Teradata
     protected ElementValueIntegerType port;
     @XmlElement(required = true)
     protected ElementValueStringType jdbcDriver;
+    protected TypePartitionsChoice numPartitions;
+    protected ElementValueStringType fetchSize;
+    protected ElementValueStringType extraUrlParams;
     protected ElementValueStringType tableName;
     protected ElementValueStringType selectQuery;
     protected ElementValueStringType countQuery;
@@ -185,6 +194,78 @@ public class Teradata
      */
     public void setJdbcDriver(ElementValueStringType value) {
         this.jdbcDriver = value;
+    }
+
+    /**
+     * Gets the value of the numPartitions property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TypePartitionsChoice }
+     *     
+     */
+    public TypePartitionsChoice getNumPartitions() {
+        return numPartitions;
+    }
+
+    /**
+     * Sets the value of the numPartitions property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TypePartitionsChoice }
+     *     
+     */
+    public void setNumPartitions(TypePartitionsChoice value) {
+        this.numPartitions = value;
+    }
+
+    /**
+     * Gets the value of the fetchSize property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getFetchSize() {
+        return fetchSize;
+    }
+
+    /**
+     * Sets the value of the fetchSize property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setFetchSize(ElementValueStringType value) {
+        this.fetchSize = value;
+    }
+
+    /**
+     * Gets the value of the extraUrlParams property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getExtraUrlParams() {
+        return extraUrlParams;
+    }
+
+    /**
+     * Sets the value of the extraUrlParams property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setExtraUrlParams(ElementValueStringType value) {
+        this.extraUrlParams = value;
     }
 
     /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/TextFileDelimited.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/TextFileDelimited.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.BooleanValueType;
 import hydrograph.engine.jaxb.commontypes.StandardCharsets;
 import hydrograph.engine.jaxb.itfd.TypeInputFileDelimitedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/TextFileFixedWidth.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/TextFileFixedWidth.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.BooleanValueType;
 import hydrograph.engine.jaxb.commontypes.StandardCharsets;
 import hydrograph.engine.jaxb.itffw.TypeFixedWidthBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/TextFileMixedScheme.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/TextFileMixedScheme.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.BooleanValueType;
 import hydrograph.engine.jaxb.commontypes.StandardCharsets;
 import hydrograph.engine.jaxb.ifmixedscheme.TypeMixedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/XmlFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/inputtypes/XmlFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.inputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.BooleanValueType;
 import hydrograph.engine.jaxb.commontypes.StandardCharsets;
 import hydrograph.engine.jaxb.ifxml.TypeInputFileXmlBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ioracle/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ioracle/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ioracle;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ioracle package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {
@@ -31,6 +40,14 @@ public class ObjectFactory {
      * 
      */
     public ObjectFactory() {
+    }
+
+    /**
+     * Create an instance of {@link TypePartitionsChoice }
+     * 
+     */
+    public TypePartitionsChoice createTypePartitionsChoice() {
+        return new TypePartitionsChoice();
     }
 
     /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ioracle/TypeInputOracleBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ioracle/TypeInputOracleBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ioracle;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.Oracle;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.Oracle;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ioracle/TypeInputOracleOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ioracle/TypeInputOracleOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ioracle;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ioracle/TypePartitionsChoice.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ioracle/TypePartitionsChoice.java
@@ -1,0 +1,162 @@
+
+/*****************************************************************************************
+ * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ ****************************************************************************************/
+
+package hydrograph.engine.jaxb.ioracle;
+
+import java.math.BigInteger;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+
+
+/**
+ * <p>Java class for type-partitions-choice complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="type-partitions-choice">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="lowerBound" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type"/>
+ *         &lt;element name="upperBound" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type"/>
+ *         &lt;element name="columnName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
+ *       &lt;/sequence>
+ *       &lt;attribute name="value" use="required" type="{http://www.w3.org/2001/XMLSchema}integer" />
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "type-partitions-choice", namespace = "hydrograph/engine/jaxb/ioracle", propOrder = {
+    "lowerBound",
+    "upperBound",
+    "columnName"
+})
+public class TypePartitionsChoice {
+
+    @XmlElement(required = true)
+    protected ElementValueIntegerType lowerBound;
+    @XmlElement(required = true)
+    protected ElementValueIntegerType upperBound;
+    @XmlElement(required = true)
+    protected ElementValueStringType columnName;
+    @XmlAttribute(name = "value", required = true)
+    protected BigInteger value;
+
+    /**
+     * Gets the value of the lowerBound property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public ElementValueIntegerType getLowerBound() {
+        return lowerBound;
+    }
+
+    /**
+     * Sets the value of the lowerBound property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public void setLowerBound(ElementValueIntegerType value) {
+        this.lowerBound = value;
+    }
+
+    /**
+     * Gets the value of the upperBound property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public ElementValueIntegerType getUpperBound() {
+        return upperBound;
+    }
+
+    /**
+     * Sets the value of the upperBound property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public void setUpperBound(ElementValueIntegerType value) {
+        this.upperBound = value;
+    }
+
+    /**
+     * Gets the value of the columnName property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getColumnName() {
+        return columnName;
+    }
+
+    /**
+     * Sets the value of the columnName property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setColumnName(ElementValueStringType value) {
+        this.columnName = value;
+    }
+
+    /**
+     * Gets the value of the value property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link BigInteger }
+     *     
+     */
+    public BigInteger getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the value of the value property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link BigInteger }
+     *     
+     */
+    public void setValue(BigInteger value) {
+        this.value = value;
+    }
+
+}

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iredshift/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iredshift/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.iredshift;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.iredshift package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iredshift/TypeInputRedshiftBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iredshift/TypeInputRedshiftBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.iredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.Redshift;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.Redshift;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iredshift/TypeInputRedshiftOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iredshift/TypeInputRedshiftOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.iredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/isparkredshift/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/isparkredshift/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.isparkredshift;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.isparkredshift package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/isparkredshift/TypeInputRedshiftOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/isparkredshift/TypeInputRedshiftOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.isparkredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/isparkredshift/TypeInputSparkredshiftBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/isparkredshift/TypeInputSparkredshiftBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.isparkredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.Sparkredshift;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.Sparkredshift;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iteradata/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iteradata/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.iteradata;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.iteradata package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {
@@ -31,6 +40,14 @@ public class ObjectFactory {
      * 
      */
     public ObjectFactory() {
+    }
+
+    /**
+     * Create an instance of {@link TypePartitionsChoice }
+     * 
+     */
+    public TypePartitionsChoice createTypePartitionsChoice() {
+        return new TypePartitionsChoice();
     }
 
     /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iteradata/TypeInputTeradataBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iteradata/TypeInputTeradataBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.iteradata;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.Teradata;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.Teradata;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iteradata/TypeInputTeradataOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iteradata/TypeInputTeradataOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.iteradata;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iteradata/TypePartitionsChoice.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/iteradata/TypePartitionsChoice.java
@@ -1,0 +1,162 @@
+
+/*****************************************************************************************
+ * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ ****************************************************************************************/
+
+package hydrograph.engine.jaxb.iteradata;
+
+import java.math.BigInteger;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+
+
+/**
+ * <p>Java class for type-partitions-choice complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="type-partitions-choice">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="lowerBound" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type"/>
+ *         &lt;element name="upperBound" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type"/>
+ *         &lt;element name="columnName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
+ *       &lt;/sequence>
+ *       &lt;attribute name="value" use="required" type="{http://www.w3.org/2001/XMLSchema}integer" />
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "type-partitions-choice", namespace = "hydrograph/engine/jaxb/iteradata", propOrder = {
+    "lowerBound",
+    "upperBound",
+    "columnName"
+})
+public class TypePartitionsChoice {
+
+    @XmlElement(required = true)
+    protected ElementValueIntegerType lowerBound;
+    @XmlElement(required = true)
+    protected ElementValueIntegerType upperBound;
+    @XmlElement(required = true)
+    protected ElementValueStringType columnName;
+    @XmlAttribute(name = "value", required = true)
+    protected BigInteger value;
+
+    /**
+     * Gets the value of the lowerBound property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public ElementValueIntegerType getLowerBound() {
+        return lowerBound;
+    }
+
+    /**
+     * Sets the value of the lowerBound property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public void setLowerBound(ElementValueIntegerType value) {
+        this.lowerBound = value;
+    }
+
+    /**
+     * Gets the value of the upperBound property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public ElementValueIntegerType getUpperBound() {
+        return upperBound;
+    }
+
+    /**
+     * Sets the value of the upperBound property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueIntegerType }
+     *     
+     */
+    public void setUpperBound(ElementValueIntegerType value) {
+        this.upperBound = value;
+    }
+
+    /**
+     * Gets the value of the columnName property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getColumnName() {
+        return columnName;
+    }
+
+    /**
+     * Sets the value of the columnName property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setColumnName(ElementValueStringType value) {
+        this.columnName = value;
+    }
+
+    /**
+     * Gets the value of the value property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link BigInteger }
+     *     
+     */
+    public BigInteger getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the value of the value property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link BigInteger }
+     *     
+     */
+    public void setValue(BigInteger value) {
+        this.value = value;
+    }
+
+}

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfd/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfd/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itfd;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.itfd package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfd/TypeInputDelimitedOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfd/TypeInputDelimitedOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itfd;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfd/TypeInputFileDelimitedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfd/TypeInputFileDelimitedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itfd;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.AvroFile;
-import hydrograph.engine.jaxb.inputtypes.TextFileDelimited;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.AvroFile;
+import hydrograph.engine.jaxb.inputtypes.TextFileDelimited;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itffw/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itffw/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itffw;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.itffw package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itffw/TypeFixedWidthBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itffw/TypeFixedWidthBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itffw;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.TextFileFixedWidth;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.TextFileFixedWidth;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itffw/TypeFixedwidthField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itffw/TypeFixedwidthField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itffw;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itffw/TypeFixedwidthRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itffw/TypeFixedwidthRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itffw;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itffw/TypeInputFixedwidthOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itffw/TypeInputFixedwidthOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itffw;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfs/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfs/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itfs;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.itfs package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfs/TypeInputFileSequenceBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfs/TypeInputFileSequenceBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itfs;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
-import hydrograph.engine.jaxb.inputtypes.SequenceInputFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.inputtypes.SequenceInputFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfs/TypeInputSequenceOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/itfs/TypeInputSequenceOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.itfs;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/JoinBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/JoinBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.join;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
-import hydrograph.engine.jaxb.operationstypes.Join;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
+import hydrograph.engine.jaxb.operationstypes.Join;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.join;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.join package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/TypeInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/TypeInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.join;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/TypeKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/TypeKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.join;
 
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.join;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/TypesOutSocketTypes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/join/TypesOutSocketTypes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.join;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.limit;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.limit package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/TypeLimitBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/TypeLimitBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.limit;
-
-import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
-import hydrograph.engine.jaxb.straightpulltypes.Limit;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
+import hydrograph.engine.jaxb.straightpulltypes.Limit;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/TypeLimitInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/TypeLimitInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.limit;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/TypeLimitOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/TypeLimitOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.limit;
-
-import hydrograph.engine.jaxb.commontypes.TypeStraightPullOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.limit;
-
-import hydrograph.engine.jaxb.commontypes.TypeStraightPullOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/TypeOutSocketAsInSocketIn0.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/limit/TypeOutSocketAsInSocketIn0.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.limit;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/lookup/LookupBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/lookup/LookupBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.lookup;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
-import hydrograph.engine.jaxb.operationstypes.Lookup;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
+import hydrograph.engine.jaxb.operationstypes.Lookup;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/lookup/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/lookup/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.lookup;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.lookup package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/lookup/TypeInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/lookup/TypeInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.lookup;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/lookup/TypeKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/lookup/TypeKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.lookup;
 
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/lookup/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/lookup/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.lookup;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/main/Graph.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/main/Graph.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.main;
 
-import hydrograph.engine.jaxb.commontypes.*;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseComponent;
+import hydrograph.engine.jaxb.commontypes.TypeCommandComponent;
+import hydrograph.engine.jaxb.commontypes.TypeInputComponent;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.commontypes.TypeProperties;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/main/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/main/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.main;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.main package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.normalize;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.normalize package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.normalize;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeOperation.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeOperation.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.normalize;
-
-import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeOperationInputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeOperationInputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.normalize;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeOperationInputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeOperationInputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.normalize;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.normalize;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeTransformExpression.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/normalize/TypeTransformExpression.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.normalize;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofmixedscheme/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofmixedscheme/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofmixedscheme;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ofmixedscheme package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofmixedscheme/TypeMixedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofmixedscheme/TypeMixedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofmixedscheme;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.TextFileMixedScheme;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.TextFileMixedScheme;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofmixedscheme/TypeMixedField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofmixedscheme/TypeMixedField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofmixedscheme;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofmixedscheme/TypeMixedRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofmixedscheme/TypeMixedRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofmixedscheme;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofmixedscheme/TypeOutputMixedInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofmixedscheme/TypeOutputMixedInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofmixedscheme;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofparquet/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofparquet/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofparquet;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ofparquet package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofparquet/TypeOutputDelimitedInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofparquet/TypeOutputDelimitedInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofparquet;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofparquet/TypeOutputFileDelimitedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofparquet/TypeOutputFileDelimitedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofparquet;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.ParquetFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.ParquetFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofsubjob/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofsubjob/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofsubjob;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ofsubjob package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofsubjob/TypeOutputDelimitedInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofsubjob/TypeOutputDelimitedInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofsubjob;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofsubjob/TypeOutputFileDelimitedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofsubjob/TypeOutputFileDelimitedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofsubjob;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.Subjob;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.Subjob;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofsubjob/TypeOutputFileDelimitedSubjob.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofsubjob/TypeOutputFileDelimitedSubjob.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofsubjob;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.SubjobOutput;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.SubjobOutput;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofxml/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofxml/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofxml;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ofxml package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofxml/TypeOutputFileXmlBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofxml/TypeOutputFileXmlBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofxml;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.XmlFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.XmlFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofxml/TypeOutputXmlInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofxml/TypeOutputXmlInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofxml;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofxml/TypeXmlField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofxml/TypeXmlField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofxml;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofxml/TypeXmlRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ofxml/TypeXmlRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ofxml;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/FieldBasicType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/FieldBasicType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/HivePartitionFieldsType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/HivePartitionFieldsType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/HivePathType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/HivePathType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/HiveType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/HiveType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohiveparquet;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ohiveparquet package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/PartitionFieldBasicType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/PartitionFieldBasicType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohiveparquet;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/TypeOutputDelimitedInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/TypeOutputDelimitedInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohiveparquet;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/TypeOutputFileDelimitedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohiveparquet/TypeOutputFileDelimitedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohiveparquet;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.ParquetHiveFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.ParquetHiveFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/FieldBasicType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/FieldBasicType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/HivePartitionFieldsType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/HivePartitionFieldsType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/HivePathType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/HivePathType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/HiveType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/HiveType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohivetextfile;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ohivetextfile package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/PartitionFieldBasicType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/PartitionFieldBasicType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohivetextfile;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/TypeOutputHiveTextFileDelimitedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/TypeOutputHiveTextFileDelimitedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohivetextfile;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.HiveTextFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.HiveTextFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/TypeOutputHiveTextFileDelimitedInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ohivetextfile/TypeOutputHiveTextFileDelimitedInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ohivetextfile;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ojdbcupdate;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
+
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ojdbcupdate package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/TypeJdbcupdateField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/TypeJdbcupdateField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ojdbcupdate;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/TypeJdbcupdateRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/TypeJdbcupdateRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ojdbcupdate;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/TypeOutputJdbcupdateBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/TypeOutputJdbcupdateBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ojdbcupdate;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.JdbcUpdate;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.JdbcUpdate;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/TypeOutputJdbcupdateOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/TypeOutputJdbcupdateOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ojdbcupdate;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/TypeUpdateKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ojdbcupdate/TypeUpdateKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,16 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ojdbcupdate;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/DatabaseType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/DatabaseType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.omysql;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/DatabaseTypeValue.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/DatabaseTypeValue.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.omysql;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.omysql;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.omysql package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeLoadChoice.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeLoadChoice.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.omysql;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeMysqlField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeMysqlField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.omysql;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeMysqlRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeMysqlRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.omysql;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeOutputMysqlBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeOutputMysqlBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.omysql;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.Mysql;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.Mysql;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeOutputMysqlOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeOutputMysqlOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.omysql;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypePrimaryKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypePrimaryKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.omysql;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeUpdateKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/omysql/TypeUpdateKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,16 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.omysql;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/DatabaseType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/DatabaseType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ooracle;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ooracle;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.ooracle package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeLoadChoice.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeLoadChoice.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ooracle;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeOracleField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeOracleField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ooracle;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeOracleRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeOracleRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ooracle;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeOutputOracleBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeOutputOracleBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ooracle;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.Oracle;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.Oracle;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeOutputOracleInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeOutputOracleInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ooracle;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypePrimaryKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypePrimaryKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ooracle;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeUpdateKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/ooracle/TypeUpdateKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,16 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.ooracle;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Aggregate.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Aggregate.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
-
-import hydrograph.engine.jaxb.aggregate.AggregateBase;
-import hydrograph.engine.jaxb.aggregate.TypePrimaryKeyFields;
-import hydrograph.engine.jaxb.aggregate.TypeSecondaryKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.aggregate.AggregateBase;
+import hydrograph.engine.jaxb.aggregate.TypePrimaryKeyFields;
+import hydrograph.engine.jaxb.aggregate.TypeSecondaryKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Cumulate.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Cumulate.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
-
-import hydrograph.engine.jaxb.cumulate.CumulateBase;
-import hydrograph.engine.jaxb.cumulate.TypePrimaryKeyFields;
-import hydrograph.engine.jaxb.cumulate.TypeSecondaryKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.cumulate.CumulateBase;
+import hydrograph.engine.jaxb.cumulate.TypePrimaryKeyFields;
+import hydrograph.engine.jaxb.cumulate.TypeSecondaryKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Executiontracking.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Executiontracking.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Filter.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Filter.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/GenerateSequence.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/GenerateSequence.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Groupcombine.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Groupcombine.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
-
-import hydrograph.engine.jaxb.groupcombine.GroupcombineBase;
-import hydrograph.engine.jaxb.groupcombine.TypePrimaryKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.groupcombine.GroupcombineBase;
+import hydrograph.engine.jaxb.groupcombine.TypePrimaryKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Join.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Join.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,20 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
 
-import hydrograph.engine.jaxb.join.JoinBase;
-import hydrograph.engine.jaxb.join.TypeKeyFields;
-
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+import hydrograph.engine.jaxb.join.JoinBase;
+import hydrograph.engine.jaxb.join.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Lookup.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Lookup.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,21 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.MatchValue;
 import hydrograph.engine.jaxb.lookup.LookupBase;
 import hydrograph.engine.jaxb.lookup.TypeKeyFields;
-
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Normalize.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Normalize.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
 
 import javax.xml.bind.annotation.XmlRegistry;
+
+
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.operationstypes package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/PartitionByExpression.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/PartitionByExpression.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.partitionbyexpression.PartitionByExpressionBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Subjob.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Subjob.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,15 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.TypeProperties;
 import hydrograph.engine.jaxb.subjob.SubjobBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Transform.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/operationstypes/Transform.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.operationstypes;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oredshift;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.oredshift package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeLoadChoice.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeLoadChoice.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oredshift;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeOutputRedshiftBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeOutputRedshiftBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.Redshift;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.Redshift;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeOutputRedshiftInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeOutputRedshiftInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypePrimaryKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypePrimaryKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeRedshiftField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeRedshiftField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeRedshiftRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeRedshiftRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeUpdateKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oredshift/TypeUpdateKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,16 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.osparkredshift;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.osparkredshift package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeLoadChoice.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeLoadChoice.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.osparkredshift;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeOutputSparkredshiftBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeOutputSparkredshiftBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.osparkredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.Sparkredshift;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.Sparkredshift;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeOutputSparkredshiftInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeOutputSparkredshiftInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.osparkredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypePrimaryKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypePrimaryKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.osparkredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeSparkredshiftField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeSparkredshiftField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.osparkredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeSparkredshiftRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeSparkredshiftRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.osparkredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeUpdateKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/osparkredshift/TypeUpdateKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,16 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.osparkredshift;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otdiscard/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otdiscard/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otdiscard;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
+
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.otdiscard package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otdiscard/TypeOutputInSocketIno.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otdiscard/TypeOutputInSocketIno.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otdiscard;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/DatabaseType.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/DatabaseType.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oteradata;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/DatabaseTypeValue.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/DatabaseTypeValue.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oteradata;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oteradata;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.oteradata package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeLoadChoice.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeLoadChoice.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oteradata;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeOutputTeradataBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeOutputTeradataBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oteradata;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.Teradata;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.Teradata;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeOutputTeradataOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeOutputTeradataOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oteradata;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypePrimaryKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypePrimaryKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oteradata;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeTeradataField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeTeradataField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oteradata;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeTeradataRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeTeradataRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oteradata;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeUpdateKeys.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/oteradata/TypeUpdateKeys.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,16 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.oteradata;
-
-import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeKeyFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfd/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfd/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otfd;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.otfd package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfd/TypeOutputDelimitedInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfd/TypeOutputDelimitedInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otfd;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfd/TypeOutputFileDelimitedBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfd/TypeOutputFileDelimitedBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otfd;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.AvroFile;
-import hydrograph.engine.jaxb.outputtypes.TextFileDelimited;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.AvroFile;
+import hydrograph.engine.jaxb.outputtypes.TextFileDelimited;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otffw/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otffw/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otffw;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.otffw package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otffw/TypeFixedWidthBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otffw/TypeFixedWidthBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otffw;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.TextFileFixedWidth;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.TextFileFixedWidth;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otffw/TypeFixedwidthField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otffw/TypeFixedwidthField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otffw;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otffw/TypeFixedwidthRecord.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otffw/TypeFixedwidthRecord.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otffw;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseRecord;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otffw/TypeOutputFixedwidthInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otffw/TypeOutputFixedwidthInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otffw;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfs/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfs/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otfs;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
+
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.otfs package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfs/TypeOutputFileSequenceBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfs/TypeOutputFileSequenceBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otfs;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
-import hydrograph.engine.jaxb.outputtypes.SequenceOutputFile;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
+import hydrograph.engine.jaxb.outputtypes.SequenceOutputFile;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfs/TypeOutputSequenceInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/otfs/TypeOutputSequenceInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.otfs;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/AvroFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/AvroFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.otfd.TypeOutputFileDelimitedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Discard.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Discard.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutputComponent;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/ExcelFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/ExcelFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.StandardCharsets;
 import hydrograph.engine.jaxb.commontypes.TypeTrueFalse;
 import hydrograph.engine.jaxb.exceltype.TypeFileExcelBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/HiveTextFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/HiveTextFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,21 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.BooleanValueType;
 import hydrograph.engine.jaxb.ohivetextfile.HivePartitionFieldsType;
 import hydrograph.engine.jaxb.ohivetextfile.HivePathType;
 import hydrograph.engine.jaxb.ohivetextfile.HiveType;
 import hydrograph.engine.jaxb.ohivetextfile.TypeOutputHiveTextFileDelimitedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/JdbcUpdate.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/JdbcUpdate.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,20 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.ojdbcupdate.TypeOutputJdbcupdateBase;
-import hydrograph.engine.jaxb.ojdbcupdate.TypeUpdateKeys;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.ojdbcupdate.TypeOutputJdbcupdateBase;
+import hydrograph.engine.jaxb.ojdbcupdate.TypeUpdateKeys;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Mysql.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Mysql.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,20 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.omysql.TypeLoadChoice;
-import hydrograph.engine.jaxb.omysql.TypeOutputMysqlBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.omysql.TypeLoadChoice;
+import hydrograph.engine.jaxb.omysql.TypeOutputMysqlBase;
 
 
 /**
@@ -42,7 +41,8 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="tableName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="username" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="password" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
- *         &lt;element name="chunkSize" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type" minOccurs="0"/>
+ *         &lt;element name="chunkSize" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
+ *         &lt;element name="extraUrlParams" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
  *         &lt;element name="loadType" type="{hydrograph/engine/jaxb/omysql}type-load-choice"/>
  *       &lt;/sequence>
  *     &lt;/extension>
@@ -62,6 +62,7 @@ import javax.xml.bind.annotation.XmlType;
     "username",
     "password",
     "chunkSize",
+    "extraUrlParams",
     "loadType"
 })
 public class Mysql
@@ -81,7 +82,8 @@ public class Mysql
     protected ElementValueStringType username;
     @XmlElement(required = true)
     protected ElementValueStringType password;
-    protected ElementValueIntegerType chunkSize;
+    protected ElementValueStringType chunkSize;
+    protected ElementValueStringType extraUrlParams;
     @XmlElement(required = true)
     protected TypeLoadChoice loadType;
 
@@ -258,10 +260,10 @@ public class Mysql
      * 
      * @return
      *     possible object is
-     *     {@link ElementValueIntegerType }
+     *     {@link ElementValueStringType }
      *     
      */
-    public ElementValueIntegerType getChunkSize() {
+    public ElementValueStringType getChunkSize() {
         return chunkSize;
     }
 
@@ -270,11 +272,35 @@ public class Mysql
      * 
      * @param value
      *     allowed object is
-     *     {@link ElementValueIntegerType }
+     *     {@link ElementValueStringType }
      *     
      */
-    public void setChunkSize(ElementValueIntegerType value) {
+    public void setChunkSize(ElementValueStringType value) {
         this.chunkSize = value;
+    }
+
+    /**
+     * Gets the value of the extraUrlParams property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getExtraUrlParams() {
+        return extraUrlParams;
+    }
+
+    /**
+     * Sets the value of the extraUrlParams property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setExtraUrlParams(ElementValueStringType value) {
+        this.extraUrlParams = value;
     }
 
     /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.outputtypes package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Oracle.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Oracle.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,20 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.ooracle.TypeLoadChoice;
-import hydrograph.engine.jaxb.ooracle.TypeOutputOracleBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.ooracle.TypeLoadChoice;
+import hydrograph.engine.jaxb.ooracle.TypeOutputOracleBase;
 
 
 /**
@@ -42,9 +41,10 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="tableName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="userName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="password" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
+ *         &lt;element name="chunkSize" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
+ *         &lt;element name="extraUrlParams" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
  *         &lt;element name="loadType" type="{hydrograph/engine/jaxb/ooracle}type-load-choice"/>
  *         &lt;element name="schemaName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
- *         &lt;element name="chunkSize" type="{hydrograph/engine/jaxb/commontypes}element-value-integer-type" minOccurs="0"/>
  *       &lt;/sequence>
  *     &lt;/extension>
  *   &lt;/complexContent>
@@ -62,9 +62,10 @@ import javax.xml.bind.annotation.XmlType;
     "tableName",
     "userName",
     "password",
+    "chunkSize",
+    "extraUrlParams",
     "loadType",
-    "schemaName",
-    "chunkSize"
+    "schemaName"
 })
 public class Oracle
     extends TypeOutputOracleBase
@@ -83,10 +84,11 @@ public class Oracle
     protected ElementValueStringType userName;
     @XmlElement(required = true)
     protected ElementValueStringType password;
+    protected ElementValueStringType chunkSize;
+    protected ElementValueStringType extraUrlParams;
     @XmlElement(required = true)
     protected TypeLoadChoice loadType;
     protected ElementValueStringType schemaName;
-    protected ElementValueIntegerType chunkSize;
 
     /**
      * Gets the value of the sid property.
@@ -257,6 +259,54 @@ public class Oracle
     }
 
     /**
+     * Gets the value of the chunkSize property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getChunkSize() {
+        return chunkSize;
+    }
+
+    /**
+     * Sets the value of the chunkSize property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setChunkSize(ElementValueStringType value) {
+        this.chunkSize = value;
+    }
+
+    /**
+     * Gets the value of the extraUrlParams property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getExtraUrlParams() {
+        return extraUrlParams;
+    }
+
+    /**
+     * Sets the value of the extraUrlParams property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setExtraUrlParams(ElementValueStringType value) {
+        this.extraUrlParams = value;
+    }
+
+    /**
      * Gets the value of the loadType property.
      * 
      * @return
@@ -302,30 +352,6 @@ public class Oracle
      */
     public void setSchemaName(ElementValueStringType value) {
         this.schemaName = value;
-    }
-
-    /**
-     * Gets the value of the chunkSize property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link ElementValueIntegerType }
-     *     
-     */
-    public ElementValueIntegerType getChunkSize() {
-        return chunkSize;
-    }
-
-    /**
-     * Sets the value of the chunkSize property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link ElementValueIntegerType }
-     *     
-     */
-    public void setChunkSize(ElementValueIntegerType value) {
-        this.chunkSize = value;
     }
 
 }

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/ParquetFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/ParquetFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.ofparquet.TypeOutputFileDelimitedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/ParquetHiveFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/ParquetHiveFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,20 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
-
-import hydrograph.engine.jaxb.ohiveparquet.HivePartitionFieldsType;
-import hydrograph.engine.jaxb.ohiveparquet.HivePathType;
-import hydrograph.engine.jaxb.ohiveparquet.HiveType;
-import hydrograph.engine.jaxb.ohiveparquet.TypeOutputFileDelimitedBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.ohiveparquet.HivePartitionFieldsType;
+import hydrograph.engine.jaxb.ohiveparquet.HivePathType;
+import hydrograph.engine.jaxb.ohiveparquet.HiveType;
+import hydrograph.engine.jaxb.ohiveparquet.TypeOutputFileDelimitedBase;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Redshift.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Redshift.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,20 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.oredshift.TypeLoadChoice;
-import hydrograph.engine.jaxb.oredshift.TypeOutputRedshiftBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.oredshift.TypeLoadChoice;
+import hydrograph.engine.jaxb.oredshift.TypeOutputRedshiftBase;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/SequenceOutputFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/SequenceOutputFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.otfs.TypeOutputFileSequenceBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Sparkredshift.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Sparkredshift.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,20 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.oredshift.TypeLoadChoice;
-import hydrograph.engine.jaxb.osparkredshift.TypeOutputSparkredshiftBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.oredshift.TypeLoadChoice;
+import hydrograph.engine.jaxb.osparkredshift.TypeOutputSparkredshiftBase;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Subjob.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Subjob.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,15 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.TypeProperties;
 import hydrograph.engine.jaxb.ofsubjob.TypeOutputFileDelimitedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/SubjobOutput.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/SubjobOutput.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
-
-import hydrograph.engine.jaxb.ofsubjob.TypeOutputFileDelimitedSubjob;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.ofsubjob.TypeOutputFileDelimitedSubjob;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Teradata.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/Teradata.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,20 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
-
-import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
-import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
-import hydrograph.engine.jaxb.oteradata.TypeLoadChoice;
-import hydrograph.engine.jaxb.oteradata.TypeOutputTeradataBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.ElementValueIntegerType;
+import hydrograph.engine.jaxb.commontypes.ElementValueStringType;
+import hydrograph.engine.jaxb.oteradata.TypeLoadChoice;
+import hydrograph.engine.jaxb.oteradata.TypeOutputTeradataBase;
 
 
 /**
@@ -42,6 +41,8 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="tableName" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="username" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="password" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
+ *         &lt;element name="chunkSize" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
+ *         &lt;element name="extraUrlParams" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type" minOccurs="0"/>
  *         &lt;element name="loadUtilityType" type="{hydrograph/engine/jaxb/commontypes}element-value-string-type"/>
  *         &lt;element name="loadType" type="{hydrograph/engine/jaxb/oteradata}type-load-choice"/>
  *       &lt;/sequence>
@@ -61,6 +62,8 @@ import javax.xml.bind.annotation.XmlType;
     "tableName",
     "username",
     "password",
+    "chunkSize",
+    "extraUrlParams",
     "loadUtilityType",
     "loadType"
 })
@@ -81,6 +84,8 @@ public class Teradata
     protected ElementValueStringType username;
     @XmlElement(required = true)
     protected ElementValueStringType password;
+    protected ElementValueStringType chunkSize;
+    protected ElementValueStringType extraUrlParams;
     @XmlElement(required = true)
     protected ElementValueStringType loadUtilityType;
     @XmlElement(required = true)
@@ -252,6 +257,54 @@ public class Teradata
      */
     public void setPassword(ElementValueStringType value) {
         this.password = value;
+    }
+
+    /**
+     * Gets the value of the chunkSize property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getChunkSize() {
+        return chunkSize;
+    }
+
+    /**
+     * Sets the value of the chunkSize property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setChunkSize(ElementValueStringType value) {
+        this.chunkSize = value;
+    }
+
+    /**
+     * Gets the value of the extraUrlParams property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public ElementValueStringType getExtraUrlParams() {
+        return extraUrlParams;
+    }
+
+    /**
+     * Sets the value of the extraUrlParams property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ElementValueStringType }
+     *     
+     */
+    public void setExtraUrlParams(ElementValueStringType value) {
+        this.extraUrlParams = value;
     }
 
     /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/TextFileDelimited.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/TextFileDelimited.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.BooleanValueType;
 import hydrograph.engine.jaxb.commontypes.StandardCharsets;
 import hydrograph.engine.jaxb.otfd.TypeOutputFileDelimitedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/TextFileFixedWidth.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/TextFileFixedWidth.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.BooleanValueType;
 import hydrograph.engine.jaxb.commontypes.StandardCharsets;
 import hydrograph.engine.jaxb.otffw.TypeFixedWidthBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/TextFileMixedScheme.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/TextFileMixedScheme.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.BooleanValueType;
 import hydrograph.engine.jaxb.commontypes.StandardCharsets;
 import hydrograph.engine.jaxb.ofmixedscheme.TypeMixedBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/XmlFile.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/outputtypes/XmlFile.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,19 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.outputtypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.BooleanValueType;
 import hydrograph.engine.jaxb.commontypes.StandardCharsets;
 import hydrograph.engine.jaxb.ofxml.TypeOutputFileXmlBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.partitionbyexpression;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.partitionbyexpression package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/PartitionByExpressionBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/PartitionByExpressionBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.partitionbyexpression;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
-import hydrograph.engine.jaxb.operationstypes.PartitionByExpression;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
+import hydrograph.engine.jaxb.operationstypes.PartitionByExpression;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypePbeInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypePbeInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.partitionbyexpression;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypePbeInputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypePbeInputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.partitionbyexpression;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationInputFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationInputFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypePbeOperation.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypePbeOperation.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.partitionbyexpression;
-
-import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeTransformOperation;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypePbeOperationInputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypePbeOperationInputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.partitionbyexpression;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypePbeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypePbeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.partitionbyexpression;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypesOutSocketTypes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/partitionbyexpression/TypesOutSocketTypes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.partitionbyexpression;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.removedups;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.removedups package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.removedups;
-
-import hydrograph.engine.jaxb.commontypes.TypeStraightPullOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypeOutSocketAsInSocketIn0.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypeOutSocketAsInSocketIn0.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.removedups;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypePrimaryKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypePrimaryKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.removedups;
 
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypeRemovedupsBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypeRemovedupsBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.removedups;
-
-import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
-import hydrograph.engine.jaxb.straightpulltypes.RemoveDups;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
+import hydrograph.engine.jaxb.straightpulltypes.RemoveDups;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypeSecondaryKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypeSecondaryKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.removedups;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypeSecondayKeyFieldsAttributes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypeSecondayKeyFieldsAttributes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.removedups;
-
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-import hydrograph.engine.jaxb.commontypes.TypeSortOrder;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
+import hydrograph.engine.jaxb.commontypes.TypeSortOrder;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypesOutSocketTypes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/removedups/TypesOutSocketTypes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.removedups;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.sort;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.sort package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.sort;
-
-import hydrograph.engine.jaxb.commontypes.TypeStraightPullOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypeOutSocketAsInSocketIn0.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypeOutSocketAsInSocketIn0.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.sort;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypePrimaryKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypePrimaryKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.sort;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypePrimaryKeyFieldsAttributes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypePrimaryKeyFieldsAttributes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.sort;
-
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-import hydrograph.engine.jaxb.commontypes.TypeSortOrder;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
+import hydrograph.engine.jaxb.commontypes.TypeSortOrder;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypeSecondaryKeyFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypeSecondaryKeyFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.sort;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypeSecondayKeyFieldsAttributes.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypeSecondayKeyFieldsAttributes.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.sort;
-
-import hydrograph.engine.jaxb.commontypes.TypeFieldName;
-import hydrograph.engine.jaxb.commontypes.TypeSortOrder;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeFieldName;
+import hydrograph.engine.jaxb.commontypes.TypeSortOrder;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypeSortBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/sort/TypeSortBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.sort;
-
-import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
-import hydrograph.engine.jaxb.straightpulltypes.Sort;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
+import hydrograph.engine.jaxb.straightpulltypes.Sort;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/Clone.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/Clone.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.straightpulltypes;
-
-import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/Limit.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/Limit.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,14 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.straightpulltypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.limit.TypeLimitBase;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,27 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.straightpulltypes;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
+
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.straightpulltypes package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/RemoveDups.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/RemoveDups.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,17 +9,20 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.straightpulltypes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import hydrograph.engine.jaxb.commontypes.KeepValue;
 import hydrograph.engine.jaxb.removedups.TypePrimaryKeyFields;
 import hydrograph.engine.jaxb.removedups.TypeRemovedupsBase;
 import hydrograph.engine.jaxb.removedups.TypeSecondaryKeyFields;
-
-import javax.xml.bind.annotation.*;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/Sort.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/Sort.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,19 +9,18 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.straightpulltypes;
-
-import hydrograph.engine.jaxb.sort.TypePrimaryKeyFields;
-import hydrograph.engine.jaxb.sort.TypeSecondaryKeyFields;
-import hydrograph.engine.jaxb.sort.TypeSortBase;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.sort.TypePrimaryKeyFields;
+import hydrograph.engine.jaxb.sort.TypeSecondaryKeyFields;
+import hydrograph.engine.jaxb.sort.TypeSortBase;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/UnionAll.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/straightpulltypes/UnionAll.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.straightpulltypes;
-
-import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeStraightPullComponent;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/subjob/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/subjob/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.subjob;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.subjob package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/subjob/SubjobBase.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/subjob/SubjobBase.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,18 +9,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.subjob;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
-import hydrograph.engine.jaxb.operationstypes.Subjob;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsComponent;
+import hydrograph.engine.jaxb.operationstypes.Subjob;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/subjob/TypeInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/subjob/TypeInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.subjob;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/subjob/TypeOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/subjob/TypeOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.subjob;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/ObjectFactory.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/ObjectFactory.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.transform;
 
@@ -18,9 +18,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 
 /**
- * The Class ObjectFactory .
- *
- * @author Bitwise
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the hydrograph.engine.jaxb.transform package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
  */
 @XmlRegistry
 public class ObjectFactory {

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeOutSocketAsInSocketIn0.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeOutSocketAsInSocketIn0.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.transform;
-
-import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOutSocketAsInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeTransformInSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeTransformInSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.transform;
-
-import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeBaseInSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeTransformOperation.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeTransformOperation.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,8 +9,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.transform;
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeTransformOperationInputField.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeTransformOperationInputField.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.transform;
-
-import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeInputField;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeTransformOperationInputFields.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeTransformOperationInputFields.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.transform;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationInputFields;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationInputFields;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeTransformOutSocket.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/jaxb/transform/TypeTransformOutSocket.java
@@ -1,5 +1,5 @@
 
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9,16 +9,15 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- ******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.jaxb.transform;
-
-import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+import hydrograph.engine.jaxb.commontypes.TypeOperationsOutSocket;
 
 
 /**

--- a/hydrograph.engine/hydrograph.engine.core/src/main/resources/newxmlschema/inputs/input-types.xsd
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/resources/newxmlschema/inputs/input-types.xsd
@@ -297,6 +297,15 @@
 						minOccurs="0" maxOccurs="1" />
 					<xs:element name="jdbcDriver" type="cmn:element-value-string-type"
 						minOccurs="1" maxOccurs="1" />
+					<!--extra params -->
+					<xs:element name="numPartitions" type="imysql:type-partitions-choice" minOccurs="0"/>
+					<xs:element name="fetchSize" type="cmn:element-value-string-type"
+								minOccurs="0" maxOccurs="1"/>
+					<xs:element name="extraUrlParams" type="cmn:element-value-string-type"
+								minOccurs="0" maxOccurs="1"/>
+
+
+					<!--end-->
 					<xs:choice maxOccurs="1" minOccurs="1">
 						<xs:element name="tableName" type="cmn:element-value-string-type"
 							minOccurs="1" maxOccurs="1" />
@@ -395,6 +404,14 @@
 						minOccurs="0" maxOccurs="1" />
 					<xs:element name="driverType" type="cmn:element-value-string-type"
 						minOccurs="1" maxOccurs="1" />
+                    <!--extra params -->
+
+                    <xs:element name="numPartitions" type="ioracle:type-partitions-choice" minOccurs="0"/>
+                    <xs:element name="fetchSize" type="cmn:element-value-string-type"
+                                minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="extraUrlParams" type="cmn:element-value-string-type"
+                                minOccurs="0" maxOccurs="1"/>
+                    <!--end-->
 					<xs:element name="userName" type="cmn:element-value-string-type"
 						minOccurs="1" maxOccurs="1" />
 					<xs:element name="password" type="cmn:element-value-string-type"
@@ -428,7 +445,13 @@
 						minOccurs="1" maxOccurs="1" />
 					<xs:element name="jdbcDriver" type="cmn:element-value-string-type"
 						minOccurs="1" maxOccurs="1" />
-
+                    <!--extra params -->
+                    <xs:element name="numPartitions" type="iteradata:type-partitions-choice" minOccurs="0"/>
+                    <xs:element name="fetchSize" type="cmn:element-value-string-type"
+                                minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="extraUrlParams" type="cmn:element-value-string-type"
+                                minOccurs="0" maxOccurs="1"/>
+                    <!--end-->
 					<xs:choice maxOccurs="1" minOccurs="1">
 						<xs:element name="tableName" type="cmn:element-value-string-type"
 							minOccurs="0" maxOccurs="1" />

--- a/hydrograph.engine/hydrograph.engine.core/src/main/resources/newxmlschema/inputs/mysql-type/input-mysql-types.xsd
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/resources/newxmlschema/inputs/mysql-type/input-mysql-types.xsd
@@ -14,6 +14,17 @@
 		namespace="hydrograph/engine/jaxb/commontypes" />
 
 
+	<xs:complexType name="type-partitions-choice">
+		<xs:sequence>
+			<xs:element name="lowerBound" type="cmn:element-value-integer-type" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="upperBound" type="cmn:element-value-integer-type" minOccurs="1" maxOccurs="1" />
+			<xs:element name="columnName" type="cmn:element-value-string-type"  minOccurs="1" maxOccurs="1"/>
+		</xs:sequence>
+		<xs:attribute name="value" type="xs:integer" use="required" />
+		<!--<xs:anyAttribute />-->
+	</xs:complexType>
+
+
 	<xs:complexType name="type-input-mysql-out-socket">
 		<xs:complexContent>
 			<xs:restriction base="cmn:type-input-outSocket">

--- a/hydrograph.engine/hydrograph.engine.core/src/main/resources/newxmlschema/inputs/oracle-type/input-oracle-types.xsd
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/resources/newxmlschema/inputs/oracle-type/input-oracle-types.xsd
@@ -14,6 +14,16 @@
 		namespace="hydrograph/engine/jaxb/commontypes" />
 
 
+	<xs:complexType name="type-partitions-choice">
+		<xs:sequence>
+			<xs:element name="lowerBound" type="cmn:element-value-integer-type" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="upperBound" type="cmn:element-value-integer-type" minOccurs="1" maxOccurs="1" />
+			<xs:element name="columnName" type="cmn:element-value-string-type"  minOccurs="1" maxOccurs="1"/>
+		</xs:sequence>
+		<xs:attribute name="value" type="xs:integer" use="required" />
+		<!--<xs:anyAttribute />-->
+	</xs:complexType>
+
 	<xs:complexType name="type-input-oracle-out-socket">
 		<xs:complexContent>
 			<xs:restriction base="cmn:type-input-outSocket">

--- a/hydrograph.engine/hydrograph.engine.core/src/main/resources/newxmlschema/inputs/teradata-type/input-teradata-types.xsd
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/resources/newxmlschema/inputs/teradata-type/input-teradata-types.xsd
@@ -1,18 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2017 Capital One Services, LLC and Bitwise, Inc. Licensed 
+<!--Copyright 2017 Capital One Services, LLC and Bitwise, Inc. Licensed
 	under the Apache License, Version 2.0 (the "License"); you may not use this 
 	file except in compliance with the License. You may obtain a copy of the 
 	License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by 
 	applicable law or agreed to in writing, software distributed under the License 
 	is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
 	KIND, either express or implied. See the License for the specific language 
-	governing permissions and limitations under the License. -->
+	governing permissions and limitations under the License.
+	-->
 <xs:schema xmlns="hydrograph/engine/jaxb/iteradata" xmlns:cmn="hydrograph/engine/jaxb/commontypes"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="hydrograph/engine/jaxb/iteradata"
 	elementFormDefault="unqualified">
 	<xs:import schemaLocation="../../common/common-types.xsd"
 		namespace="hydrograph/engine/jaxb/commontypes" />
 
+	<xs:complexType name="type-partitions-choice">
+		<xs:sequence>
+			<xs:element name="lowerBound" type="cmn:element-value-integer-type" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="upperBound" type="cmn:element-value-integer-type" minOccurs="1" maxOccurs="1" />
+			<xs:element name="columnName" type="cmn:element-value-string-type"  minOccurs="1" maxOccurs="1"/>
+		</xs:sequence>
+		<xs:attribute name="value" type="xs:integer" use="required" />
+		<!--<xs:anyAttribute />-->
+	</xs:complexType>
 
 	<xs:complexType name="type-input-teradata-out-socket">
 		<xs:complexContent>

--- a/hydrograph.engine/hydrograph.engine.core/src/main/resources/newxmlschema/outputs/output-types.xsd
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/resources/newxmlschema/outputs/output-types.xsd
@@ -351,8 +351,12 @@
                                 minOccurs="1" maxOccurs="1"/>
                     <xs:element name="password" type="cmn:element-value-string-type"
                                 minOccurs="1" maxOccurs="1"/>
-                    <xs:element name="chunkSize" type="cmn:element-value-integer-type"
+                    <!--new params additions -->
+                    <xs:element name="chunkSize" type="cmn:element-value-string-type"
                                 minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="extraUrlParams" type="cmn:element-value-string-type"
+                                minOccurs="0" maxOccurs="1"/>
+                    <!--END-->
                     <xs:element name="loadType" type="omysql:type-load-choice"
                                 minOccurs="1"/>
                 </xs:sequence>
@@ -437,11 +441,15 @@
                                 minOccurs="1" maxOccurs="1"/>
                     <xs:element name="password" type="cmn:element-value-string-type"
                                 minOccurs="1" maxOccurs="1"/>
+                    <!--new params additions -->
+                    <xs:element name="chunkSize" type="cmn:element-value-string-type"
+                                minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="extraUrlParams" type="cmn:element-value-string-type"
+                                minOccurs="0" maxOccurs="1"/>
+                    <!--END-->
                     <xs:element name="loadType" type="ooracle:type-load-choice"
                                 minOccurs="1"/>
                     <xs:element name="schemaName" type="cmn:element-value-string-type"
-                                minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="chunkSize" type="cmn:element-value-integer-type"
                                 minOccurs="0" maxOccurs="1"/>
                 </xs:sequence>
             </xs:extension>
@@ -466,6 +474,12 @@
                                 minOccurs="1" maxOccurs="1"/>
                     <xs:element name="password" type="cmn:element-value-string-type"
                                 minOccurs="1" maxOccurs="1"/>
+                    <!--new params additions -->
+                    <xs:element name="chunkSize" type="cmn:element-value-string-type"
+                                minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="extraUrlParams" type="cmn:element-value-string-type"
+                                minOccurs="0" maxOccurs="1"/>
+                    <!--END-->
                     <xs:element name="loadUtilityType" type="cmn:element-value-string-type"
                                 minOccurs="1" maxOccurs="1"/>
                     <!-- <xs:element name="chunkSize" type="cmn:element-value-integer-type"

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputMysqlComponent.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputMysqlComponent.scala
@@ -1,16 +1,18 @@
-/** *****************************************************************************
-  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  * http://www.apache.org/licenses/LICENSE-2.0
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  * ******************************************************************************/
+/*****************************************************************************************
+ * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ ****************************************************************************************/
 package hydrograph.engine.spark.components
+
+import java.util.Properties
 
 import hydrograph.engine.core.component.entity.InputRDBMSEntity
 import hydrograph.engine.spark.components.base.InputComponentBase
@@ -39,10 +41,35 @@ class InputMysqlComponent(inputRDBMSEntity: InputRDBMSEntity, iComponentsParams:
 
     val sparkSession = iComponentsParams.getSparkSession()
 
-    val properties = inputRDBMSEntity.getRuntimeProperties
+    //post open source changes for optimization and flexibility
+    val numPartitions: Int = inputRDBMSEntity getNumPartitionsValue
+
+    val lowerBound: Int = inputRDBMSEntity getLowerBound
+
+    val upperBound: Int = inputRDBMSEntity getUpperBound
+
+
+
+    val fetchSizeValue: String = inputRDBMSEntity getFetchSize match {
+      case null => "1000"
+      case _    => inputRDBMSEntity getFetchSize
+    }
+    LOG.info("using fetchsize" + fetchSizeValue)
+
+    val columnForPartitioning: String = inputRDBMSEntity.getColumnName
+    val extraUrlParams: String = inputRDBMSEntity.getExtraUrlParameters match {
+      case null => ""
+      case _ => "?"+inputRDBMSEntity.getExtraUrlParameters
+    }
+
+
+    val properties: Properties = inputRDBMSEntity.getRuntimeProperties
+    val driverName: String = "com.mysql.jdbc.Driver"
+
     properties.setProperty("user", inputRDBMSEntity.getUsername)
     properties.setProperty("password", inputRDBMSEntity.getPassword)
-    val driverName = "com.mysql.jdbc.Driver"
+    properties.setProperty("fetchsize", fetchSizeValue)
+
 
     if (inputRDBMSEntity.getJdbcDriver.equals("Connector/J")) {
       properties.setProperty("driver", driverName)
@@ -59,20 +86,31 @@ class InputMysqlComponent(inputRDBMSEntity: InputRDBMSEntity, iComponentsParams:
     else "(" + DbTableUtils().getSelectQuery(inputRDBMSEntity.getFieldsList.asScala.toList, inputRDBMSEntity.getTableName) + ") as alias"
 
     val connectionURL = "jdbc:mysql://" + inputRDBMSEntity.getHostName + ":" + inputRDBMSEntity.getPort + "/" +
-      inputRDBMSEntity.getDatabaseName
+      inputRDBMSEntity.getDatabaseName+extraUrlParams
 
     LOG.info("Connection url for Mysql input component: " + connectionURL)
 
+    def createJdbcDataframe: Int => DataFrame = (partitionValue:Int) => partitionValue match {
+      case Int.MinValue => sparkSession.read.jdbc(connectionURL, selectQuery, properties)
+      case (partitionValues: Int)  =>  sparkSession.read.jdbc(connectionURL,
+                    selectQuery,
+                    columnForPartitioning,
+                    lowerBound,
+                    upperBound,
+                    partitionValues,
+                    properties)
+    }
+
     try {
-      val df = sparkSession.read.jdbc(connectionURL, selectQuery, properties)
-      SchemaUtils().compareSchema(getMappedSchema(schemaField), df.schema.toList)
+      val df: DataFrame = createJdbcDataframe(numPartitions)
+      SchemaUtils().compareSchema(getMappedSchema (schemaField), df.schema.toList)
       val key = inputRDBMSEntity.getOutSocketList.get(0).getSocketId
       Map(key -> df)
 
     } catch {
       case e: Exception =>
         LOG.error("Error in Input  Mysql component '" + inputRDBMSEntity.getComponentId + "', " + e.getMessage, e)
-        throw new DatabaseConnectionException("Error in Input Mysql Component " + inputRDBMSEntity.getComponentId, e)
+        throw new RuntimeException("Error in Input Mysql Component " + inputRDBMSEntity.getComponentId, e)
     }
   }
 

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputOracleComponent.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputOracleComponent.scala
@@ -1,15 +1,15 @@
-/** *****************************************************************************
-  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  * http://www.apache.org/licenses/LICENSE-2.0
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  * ******************************************************************************/
+/*****************************************************************************************
+ * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ ****************************************************************************************/
 package hydrograph.engine.spark.components
 
 import hydrograph.engine.core.component.entity.InputRDBMSEntity
@@ -34,9 +34,35 @@ class InputOracleComponent(inputRDBMSEntity: InputRDBMSEntity, iComponentsParams
   override def createComponent(): Map[String, DataFrame] = {
     val schemaField = SchemaCreator(inputRDBMSEntity).makeSchema()
     val sparkSession = iComponentsParams.getSparkSession()
+
+    //post open source changes for optimization and flexibility
+    val numPartitions: Int = inputRDBMSEntity getNumPartitionsValue
+
+    val lowerBound: Int = inputRDBMSEntity getLowerBound
+
+    val upperBound: Int = inputRDBMSEntity getUpperBound
+
+
+
+    val fetchSizeValue: String = inputRDBMSEntity getFetchSize match {
+      case null => "1000"
+      case _    => inputRDBMSEntity getFetchSize
+    }
+    LOG.info("using fetchsize" + fetchSizeValue)
+
+    val columnForPartitioning: String = inputRDBMSEntity.getColumnName
+    val extraUrlParams: String = inputRDBMSEntity.getExtraUrlParameters match {
+      case null => ""
+      case _ => ","+inputRDBMSEntity.getExtraUrlParameters
+    }
+
+
+
     val properties = inputRDBMSEntity.getRuntimeProperties;
+
     properties.setProperty("user", inputRDBMSEntity.getUsername)
     properties.setProperty("password", inputRDBMSEntity.getPassword)
+    properties.setProperty("fetchsize", fetchSizeValue)
 
     LOG.info("Created Input Oracle Component '" + inputRDBMSEntity.getComponentId
       + "' in Batch " + inputRDBMSEntity.getBatch
@@ -59,20 +85,36 @@ class InputOracleComponent(inputRDBMSEntity: InputRDBMSEntity, iComponentsParams
         + " having schema: [ " + inputRDBMSEntity.getFieldsList.asScala.mkString(",") + " ]"
         + " reading data from '" + selectQuery + "' query")
 
-    val connectionURL = "jdbc:oracle:" + inputRDBMSEntity.getDriverType + "://@" + inputRDBMSEntity.getHostName + ":" + inputRDBMSEntity.getPort() + "/" +
-      inputRDBMSEntity.getSid;
+    val connectionURL: String = "jdbc:oracle:" + inputRDBMSEntity.getDriverType + "://@" + inputRDBMSEntity.getHostName + ":" + inputRDBMSEntity.getPort() + "/" +
+      inputRDBMSEntity.getSid+extraUrlParams
 
     LOG.info("Connection  url for Oracle input component: " + connectionURL)
 
+
+    def createJdbcDataframe: Int => DataFrame = (partitionValue:Int) => partitionValue match {
+      case Int.MinValue => sparkSession.read.jdbc(connectionURL, selectQuery, properties)
+      case (partitionValues: Int)  =>  sparkSession.read.jdbc(connectionURL,
+        selectQuery,
+        columnForPartitioning,
+        lowerBound,
+        upperBound,
+        partitionValue,
+        properties)
+    }
+
+
+
     try {
-      val df = sparkSession.read.jdbc(connectionURL, selectQuery, properties)
+      val df = createJdbcDataframe(numPartitions)
+
       compareSchema(getSchema(schemaField), getMappedSchema(df.schema))
+
       val key = inputRDBMSEntity.getOutSocketList.get(0).getSocketId
       Map(key -> df)
     } catch {
       case e: Exception =>
         LOG.error("Error in Input  Oracle input component '" + inputRDBMSEntity.getComponentId + "', Error" + e.getMessage, e)
-        throw new DatabaseConnectionException("Error in Input Oracle Component " + inputRDBMSEntity.getComponentId, e)
+        throw new RuntimeException("Error in Input Oracle Component " + inputRDBMSEntity.getComponentId, e)
     }
   }
 

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputTeradataComponent.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputTeradataComponent.scala
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -8,8 +8,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.spark.components
 
@@ -38,10 +38,25 @@ class InputTeradataComponent(inputRDBMSEntity: InputRDBMSEntity,
     val schemaField = SchemaCreator(inputRDBMSEntity).makeSchema()
 
     val sparkSession = iComponentsParams.getSparkSession()
+    val numPartitions: Int = inputRDBMSEntity getNumPartitionsValue
+    val upperBound: Int = inputRDBMSEntity getUpperBound
+    val lowerBound: Int = inputRDBMSEntity getLowerBound
+
+    val fetchSizeValue: String = inputRDBMSEntity getFetchSize match {
+      case null => "1000"
+      case _    => inputRDBMSEntity getFetchSize
+    }
+    val columnForPartitioning: String = inputRDBMSEntity.getColumnName
+    val extraUrlParams: String = inputRDBMSEntity.getExtraUrlParameters match {
+      case null => ""
+      case _ => ","+inputRDBMSEntity.getExtraUrlParameters
+    }
+
 
     val properties = inputRDBMSEntity.getRuntimeProperties
     properties.setProperty("user", inputRDBMSEntity.getUsername)
     properties.setProperty("password", inputRDBMSEntity.getPassword)
+    properties.setProperty("fetchsize", fetchSizeValue)
     val driverName = "com.teradata.jdbc.TeraDriver"
 
     if (inputRDBMSEntity.getJdbcDriver().equals("TeraJDBC4")) {
@@ -72,14 +87,24 @@ class InputTeradataComponent(inputRDBMSEntity: InputRDBMSEntity,
 
 
 
-    val connectionURL = "jdbc:teradata://" + inputRDBMSEntity.getHostName() + "/DBS_PORT=" + inputRDBMSEntity.getPort() + ",DATABASE=" +
-      inputRDBMSEntity.getDatabaseName()+",TYPE=DEFAULT";
+    val connectionURL: String = "jdbc:teradata://" + inputRDBMSEntity.getHostName() + "/DBS_PORT=" + inputRDBMSEntity.getPort() + ",DATABASE=" +
+      inputRDBMSEntity.getDatabaseName()+",TYPE=DEFAULT"+extraUrlParams
     /*+inputRDBMSEntity.get_interface()+*/
     LOG.info("Connection  url for Teradata input component: " + connectionURL)
 
 
+    def createJdbcDataframe: Int => DataFrame = (partitionValue:Int) => partitionValue match {
+      case Int.MinValue => sparkSession.read.jdbc(connectionURL, selectQuery, properties)
+      case (partitionValues: Int)  =>  sparkSession.read.jdbc(connectionURL,
+        selectQuery,
+        columnForPartitioning,
+        lowerBound,
+        upperBound,
+        partitionValues,
+        properties)
+    }
     try {
-      val df = sparkSession.read.jdbc(connectionURL, selectQuery, properties)
+      val df: DataFrame = createJdbcDataframe(numPartitions)
       SchemaUtils().compareSchema(getMappedSchema(schemaField),df.schema.toList)
       val key = inputRDBMSEntity.getOutSocketList.get(0).getSocketId
       Map(key -> df)

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/OutputTeradataComponent.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/OutputTeradataComponent.scala
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*****************************************************************************************
  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -8,8 +8,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+ * limitations under the License
+ ****************************************************************************************/
 
 package hydrograph.engine.spark.components
 
@@ -29,12 +29,6 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConverters._
 
-/**
-  * The Class OutputTeradataComponent.
-  *
-  * @author Bitwise
-  *
-  */
 class OutputTeradataComponent(outputRDBMSEntity: OutputRDBMSEntity,
                               cp: BaseComponentParams) extends SparkFlow {
 
@@ -43,9 +37,22 @@ class OutputTeradataComponent(outputRDBMSEntity: OutputRDBMSEntity,
 
   override def execute(): Unit = {
 
+    val batchSize: String = outputRDBMSEntity.getChunkSize match {
+      case null => "1000"
+      case _  => outputRDBMSEntity.getChunkSize
+    }
+
+    LOG.info("Using batchsize "+ batchSize)
+
+    val extraUrlParameters: String = outputRDBMSEntity.getExtraUrlParamters match {
+      case null => ""
+      case _    => "," + outputRDBMSEntity.getExtraUrlParamters
+    }
+
     val properties = outputRDBMSEntity.getRuntimeProperties
     properties.setProperty("user", outputRDBMSEntity.getUsername)
     properties.setProperty("password", outputRDBMSEntity.getPassword)
+    properties.setProperty("batchsize", batchSize)
     val driverName = "com.teradata.jdbc.TeraDriver"
 
     if (outputRDBMSEntity.getJdbcDriver().equals("TeraJDBC4")) {
@@ -54,7 +61,7 @@ class OutputTeradataComponent(outputRDBMSEntity: OutputRDBMSEntity,
 
 
     val connectionURL = "jdbc:teradata://" + outputRDBMSEntity.getHostName() + "/DBS_PORT="+outputRDBMSEntity.getPort()+",DATABASE=" +
-      outputRDBMSEntity.getDatabaseName()+",TYPE=DEFAULT,TMODE=ANSI";
+      outputRDBMSEntity.getDatabaseName()+",TYPE=DEFAULT,TMODE=ANSI"+extraUrlParameters
     /*outputRDBMSEntity.get_interface()*/
 
     LOG.info("Created Output Teradata Component '"+ outputRDBMSEntity.getComponentId
@@ -153,10 +160,10 @@ class OutputTeradataComponent(outputRDBMSEntity: OutputRDBMSEntity,
       case e: SQLException =>
         LOG.error("Error while connecting to database " + e.getMessage)
 
-        throw new RuntimeException("Error message " ,e)
+        throw new RuntimeException("Error message " + e.getMessage ,e)
       case e: Exception =>
         LOG.error("Error while executing '"+ query + "' query in executeQuery()" )
-        throw new RuntimeException("Error message " ,e)
+        throw new RuntimeException("Error message " + e.getMessage , e)
     }
   }
 

--- a/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/DelimitedInputTeradataOutput.xml
+++ b/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/DelimitedInputTeradataOutput.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License
- -->
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
 <p:graph name="DelimitedInputAndTeradataOutput" xmlns:p="hydrograph/engine/jaxb/main"
          xmlns:it="hydrograph/engine/jaxb/inputtypes" xmlns:ot="hydrograph/engine/jaxb/outputtypes"
@@ -26,7 +26,7 @@
                 <field name="givennameapplicant" type="java.lang.String" />
                 <field name="surnameapplicant" type="java.lang.String" />
                 <field name="gender" type="java.lang.String" />
-                <field name="alias1" type="java.lang.Boolean" />
+                <field name="alias" type="java.lang.Boolean" />
                 <field name="checkPrevName" type="java.lang.Boolean" />
                 <field name="dt_dob" type="java.util.Date" format="yyyy/MM/dd" />
                 <field name="validityRequired" type="java.lang.Boolean" />
@@ -72,9 +72,10 @@
                 <field name="checkImpoundedRevoked" type="java.lang.Boolean" />
                 <field name="tf_passportNumber_revoke" type="java.lang.Long" />
                 <field name="ecDateofIssue" type="java.util.Date" format="yyyy/MM/dd" />
+
             </schema>
         </outSocket>
-        <path uri="hydrograph.engine.spark/testData/inputFiles/250mb.txt" />
+        <path uri="hydrograph.engine.spark/testData/input/mysql_2l" />
         <delimiter value="," />
         <hasHeader value="false" />
     </inputs>
@@ -88,7 +89,7 @@
                 <field name="givennameapplicant" type="java.lang.String" />
                 <field name="surnameapplicant" type="java.lang.String" />
                 <field name="gender" type="java.lang.String" />
-                <field name="alias1" type="java.lang.Boolean" />
+                <field name="alias" type="java.lang.Boolean" />
                 <field name="checkPrevName" type="java.lang.Boolean" />
                 <field name="dt_dob" type="java.util.Date" format="yyyy/MM/dd" />
                 <field name="validityRequired" type="java.lang.Boolean" />
@@ -141,20 +142,14 @@
         <hostName value="10.130.250.235" />
         <port value="1025" />
         <jdbcDriver value="TeraJDBC4" />
-        <tableName value="benchmarking_00100" />
+        <tableName value="benchmarking_002" />
         <username value="hydrograph1" />
         <password value="teradata" />
         <chunkSize value="100000"/>
         <loadUtilityType value="DEFAULT"/>
-
-
-            <loadType>
-               <newTable></newTable>
-            </loadType>
-
-            <!--<Insert/>-->
+        <loadType>
+            <Insert></Insert>
             <!-- <truncateLoad/>-->
-
-
+        </loadType>
     </outputs>
 </p:graph>

--- a/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/InputOracleSimple.xml
+++ b/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/InputOracleSimple.xml
@@ -1,86 +1,155 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License
- -->
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<p:graph xmlns:p="hydrograph/engine/jaxb/main" xmlns:it="hydrograph/engine/jaxb/inputtypes"
-         xmlns:ot="hydrograph/engine/jaxb/outputtypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         name="Oracle INPUT EXAMPLE"
-         xsi:schemaLocation="hydrograph/engine/jaxb/main ../../../hydrograph.engine.core/src/main/resources/newxmlschema/main/main.xsd  ">
+<p:graph name="InputOracleSimple" xmlns:p="hydrograph/engine/jaxb/main"
+         xmlns:it="hydrograph/engine/jaxb/inputtypes" xmlns:ot="hydrograph/engine/jaxb/outputtypes"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="hydrograph/engine/jaxb/main ../../../hydrograph.engine.core/src/main/resources/newxmlschema/main/main.xsd">
 
-    <inputs id="oracle" batch="0" xsi:type="it:oracle">
+
+    <inputs id="inputOracle" batch="0" xsi:type="it:oracle">
         <outSocket id="out0">
             <schema name="schema1">
-                <field name="aa" type="java.lang.Short"/>
-                  <field name="bb" type="java.lang.Boolean"/>
-                  <field name="cc" type="java.lang.Long"/>
-                  <field name="dd" type="java.lang.Float"/>
-                  <field name="ee" type="java.lang.Integer"/>
-                  <field name="gg" type="java.lang.String"/>
-                  <field name="ff" type="java.lang.Double"/>
-                  <field name="hh" type="java.util.Date" format="yyyy-MM-dd"/>
-                  <field name="ii" type="java.util.Date" format="yyyy-MM-dd HH:mm:ss"/>
-                  <field name="jj" type="java.math.BigDecimal" scale="2"
-                         precision="10" scaleType="explicit"/>
+                <field name="APPLYINGFOR" type="java.lang.String" />
+                <field name="APPTYPE" 		type="java.lang.String" />
+                <field name="BOOKLETTYPE" type="java.lang.String" />
+                <field name="GIVENNAMEAPPLICANT" type="java.lang.String" />
+                <field name="SURNAMEAPPLICANT" type="java.lang.String" />
+                <field name="GENDER" type="java.lang.String" />
+                <field name="ALIAS" type="java.lang.String" />
+                <field name="CHECKPREVNAME" type="java.lang.String" />
+                <field name="DT_DOB" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="VALIDITYREQUIRED" type="java.lang.String" />
+                <field name="CHECKPOBOUTSIDEINDIA" type="java.lang.String" />
+                <field name="POB" type="java.lang.String" />
+                <field name="COUNTRY" type="java.lang.String" />
+                <field name="STATE" type="java.lang.String" />
+                <field name="STATEPROVINCE" type="java.lang.String" />
+                <field name="MARITALSTATUS" type="java.lang.String" />
+                <field name="CITIZENSHIPOFINDIABY" type="java.lang.String" />
+                <field name="PAN" type="java.lang.Long" />
+                <field name="VOTEID" type="java.lang.Long" />
+                <field name="EMPLOYMENTTYPE" type="java.lang.String" />
+                <field name="ORGANIZATIONNAME" type="java.lang.String" />
+                <field name="PARENTSPOUSEGOVTEMP" type="java.lang.String" />
+                <field name="EDUCATIONALQUALIFICATION" type="java.lang.String" />
+                <field name="NONECR" type="java.lang.String" />
+                <field name="AADHAARNUMBER" type="java.lang.Long" />
+                <field name="FATHERGUARDIANFILEPASSNUMBER" type="java.math.BigDecimal" scale="3" scaleType="explicit" precision="7" />
+                <field name="FATHERGUARDIANISNOTINDIAN" type="java.lang.String" />
+                <field name="MOTHERGUARDIANFILEPASSNUMBER" type="java.lang.Long" />
+                <field name="MOTHERGUARDIANISNOTINDIAN" type="java.lang.String" />
+                <field name="CHECKTEMPVISIT" type="java.lang.String" />
+                <field name="RESIDINGSINCEMONTH" type="java.lang.String" />
+                <field name="RESIDINGSINCEYEAR" type="java.lang.Integer" />
+                <field name="STATEPRESENTADD" type="java.lang.String" />
+                <field name="PIN" type="java.lang.Long" />
+                <field name="MOBILENUMBER" type="java.lang.Long" />
+                <field name="TELEPHONENUMBER" type="java.lang.Long" />
+                <field name="CHECKDIPLOMAATICOFFICIAL" type="java.lang.String" />
+                <field name="TF_DIPLOFFICIALPASSPORTNUMBER" type="java.lang.Long" />
+                <field name="DDISSUEDATE" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="DDEXPIRYDATE" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="CHECKAPPLIEDPP" type="java.lang.String" />
+                <field name="FILENUMBER" type="java.math.BigDecimal" scale="5" scaleType="explicit" precision="9" />
+                <field name="MONTHOFAPPLYING" type="java.lang.String" />
+                <field name="YEAROFAPPLYING" type="java.lang.Integer" />
+                <field name="CHECKCRIMINAL" type="java.lang.String" />
+                <field name="CHECKOFFENCE5YEARS" type="java.lang.String" />
+                <field name="CHECKPASSPORTREFUSED" type="java.lang.String" />
+                <field name="CHECKIMPOUNDEDREVOKED" type="java.lang.String" />
+                <field name="TF_PASSPORTNUMBER_REVOKE" type="java.lang.Long" />
+                <field name="ECDATEOFISSUE" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
             </schema>
         </outSocket>
-        <sid value="PRACTICE"/>
+      <sid value="PRACTICE"/>
         <hostName value="DBDEVSRV"/>
         <port value="1521"/>
         <driverType value="thin"/>
-        <userName value="HTCD"/>
+
+        <numPartitions value="6">
+            <lowerBound value="110"/>
+            <upperBound value="116"/>
+            <columnName value="yearofApplying"/>
+        </numPartitions>
+        <fetchSize value="100000"/>
+        <userName value="htcd"/>
         <password value="Bitwise2017"/>
+        <tableName value="benchmarking_002"/>
 
-        <!--<jdbcurl value="jdbc:oracle:thin://@DBDEVSRV:1521:PRACTICE" />
-        <condition value="num > 11" />
-        <batchSize value="1" />
--->
-        <!-- <query value="select testingtable1.num as num,testingtable1.lwr as
-            lwr,testingtable1.upr as upr from testingtable2 inner join testingtable1
-            on testingtable2.num!=testingtable1.num " /> -->
-        <!-- <query value="select sum(testingTable.num) as num,testingTable.lwr
-            as lwr from testingTable group by testingTable.lwr " /> -->
 
-        <!-- <query value="SELECT * FROM testingTable t JOIN testingTable2 t2 ON
-            t.NUM = t2.NUM" /> -->
-        <!-- <query value="SELECT * FROM testingTable4 t JOIN testingTable2 t2
-            ON t.NUM = t2.NUM" /> -->
-        <!--  <selectQuery value="SELECT * FROM Hydrograph_UI_test46"/>-->
-        <tableName value="testingTableAllTablesbatchSize"/>
     </inputs>
 
-    <outputs id="OFDelimited_01" batch="0" xsi:type="ot:textFileDelimited">
-        <inSocket fromComponentId="oracle" fromSocketId="out0" id="in0"
-                  type="in">
-            <schema name="schema2">
-                <field name="aa" type="java.lang.Short"/>
-                <field name="bb" type="java.lang.Boolean"/>
-                <field name="cc" type="java.lang.Long"/>
-                <field name="dd" type="java.lang.Float"/>
-                <field name="ee" type="java.lang.Integer"/>
-                <field name="gg" type="java.lang.String"/>
-                <field name="ff" type="java.lang.Double"/>
-                <field name="hh" type="java.util.Date" format="yyyy-MM-dd"/>
-                <field name="ii" type="java.util.Date" format="yyyy-MM-dd HH:mm:ss"/>
-                <field name="jj" type="java.math.BigDecimal" scale="2"
-                       precision="10" scaleType="explicit"/>
+    <outputs id="output1" xsi:type="ot:textFileDelimited">
+        <inSocket  fromComponentId="inputOracle" fromSocketId="out0" id="in0">
+            <schema name="outSchema">
+                <field name="APPLYINGFOR" type="java.lang.String" />
+                <field name="APPTYPE" 		type="java.lang.String" />
+                <field name="BOOKLETTYPE" type="java.lang.String" />
+                <field name="GIVENNAMEAPPLICANT" type="java.lang.String" />
+                <field name="SURNAMEAPPLICANT" type="java.lang.String" />
+                <field name="GENDER" type="java.lang.String" />
+                <field name="ALIAS" type="java.lang.String" />
+                <field name="CHECKPREVNAME" type="java.lang.String" />
+                <field name="DT_DOB" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="VALIDITYREQUIRED" type="java.lang.String" />
+                <field name="CHECKPOBOUTSIDEINDIA" type="java.lang.String" />
+                <field name="POB" type="java.lang.String" />
+                <field name="COUNTRY" type="java.lang.String" />
+                <field name="STATE" type="java.lang.String" />
+                <field name="STATEPROVINCE" type="java.lang.String" />
+                <field name="MARITALSTATUS" type="java.lang.String" />
+                <field name="CITIZENSHIPOFINDIABY" type="java.lang.String" />
+                <field name="PAN" type="java.lang.Long" />
+                <field name="VOTEID" type="java.lang.Long" />
+                <field name="EMPLOYMENTTYPE" type="java.lang.String" />
+                <field name="ORGANIZATIONNAME" type="java.lang.String" />
+                <field name="PARENTSPOUSEGOVTEMP" type="java.lang.String" />
+                <field name="EDUCATIONALQUALIFICATION" type="java.lang.String" />
+                <field name="NONECR" type="java.lang.String" />
+                <field name="AADHAARNUMBER" type="java.lang.Long" />
+                <field name="FATHERGUARDIANFILEPASSNUMBER" type="java.math.BigDecimal" scale="3" scaleType="explicit" precision="7" />
+                <field name="FATHERGUARDIANISNOTINDIAN" type="java.lang.String" />
+                <field name="MOTHERGUARDIANFILEPASSNUMBER" type="java.lang.Long" />
+                <field name="MOTHERGUARDIANISNOTINDIAN" type="java.lang.String" />
+                <field name="CHECKTEMPVISIT" type="java.lang.String" />
+                <field name="RESIDINGSINCEMONTH" type="java.lang.String" />
+                <field name="RESIDINGSINCEYEAR" type="java.lang.Integer" />
+                <field name="STATEPRESENTADD" type="java.lang.String" />
+                <field name="PIN" type="java.lang.Long" />
+                <field name="MOBILENUMBER" type="java.lang.Long" />
+                <field name="TELEPHONENUMBER" type="java.lang.Long" />
+                <field name="CHECKDIPLOMAATICOFFICIAL" type="java.lang.String" />
+                <field name="TF_DIPLOFFICIALPASSPORTNUMBER" type="java.lang.Long" />
+                <field name="DDISSUEDATE" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="DDEXPIRYDATE" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="CHECKAPPLIEDPP" type="java.lang.String" />
+                <field name="FILENUMBER" type="java.math.BigDecimal" scale="5" scaleType="explicit" precision="9" />
+                <field name="MONTHOFAPPLYING" type="java.lang.String" />
+                <field name="YEAROFAPPLYING" type="java.lang.Integer" />
+                <field name="CHECKCRIMINAL" type="java.lang.String" />
+                <field name="CHECKOFFENCE5YEARS" type="java.lang.String" />
+                <field name="CHECKPASSPORTREFUSED" type="java.lang.String" />
+                <field name="CHECKIMPOUNDEDREVOKED" type="java.lang.String" />
+                <field name="TF_PASSPORTNUMBER_REVOKE" type="java.lang.Long" />
+                <field name="ECDATEOFISSUE" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
             </schema>
         </inSocket>
-        <path uri="hydrograph.engine.spark/testData/output/oracleOutput1"/>
-        <delimiter value=","/>
-        <hasHeader value="false"/>
-        <safe value="false"/>
-        <strict value="true"/>
-        <charset value="UTF-8"/>
+        <overWrite value="true"/>
+        <path uri="hydrograph.engine.spark/testData/input/oracle_2l" />
+        <delimiter value="," />
+        <hasHeader value="false" />
+        <charset value="ISO-8859-1" />
     </outputs>
-
 </p:graph>

--- a/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/MysqlInputDelimitedOutput.xml
+++ b/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/MysqlInputDelimitedOutput.xml
@@ -21,44 +21,137 @@
    <inputs id="inputMysql" batch="0" xsi:type="it:mysql">
     <outSocket id="out0">
         <schema name="schema1">
-            <field name="id" type="java.lang.Integer" />
-            <field name="name" type="java.lang.String" />
-            <field name="city" type="java.lang.String" />
-            <field name="creditPoint" type="java.lang.Double" />
-            <field name="Deptno" type="java.lang.Integer" />
-            <field name="dob" type="java.util.Date" format="yyyy-MM-dd"/>
-            <field name="dobj" type="java.util.Date" format="yyyy-MM-dd HH:mm:ss" />
-            <field name="extra" type="java.math.BigDecimal" scale="2"
-                   precision="10" scaleType="explicit" />
+            <field name="applyingFor" type="java.lang.String" />
+            <field name="apptype" type="java.lang.String" />
+            <field name="bookletType" type="java.lang.String" />
+            <field name="givennameapplicant" type="java.lang.String" />
+            <field name="surnameapplicant" type="java.lang.String" />
+            <field name="gender" type="java.lang.String" />
+            <field name="alias" type="java.lang.Boolean" />
+            <field name="checkPrevName" type="java.lang.Boolean" />
+            <field name="dt_dob" type="java.util.Date" format="yyyy/MM/dd" />
+            <field name="validityRequired" type="java.lang.Boolean" />
+            <field name="checkPOBOutsideIndia" type="java.lang.Boolean" />
+            <field name="POB" type="java.lang.String" />
+            <field name="country" type="java.lang.String" />
+            <field name="state" type="java.lang.String" />
+            <field name="stateProvince" type="java.lang.String" />
+            <field name="maritalStatus" type="java.lang.String" />
+            <field name="citizenshipOfIndiaBy" type="java.lang.String" />
+            <field name="PAN" type="java.lang.Long" />
+            <field name="voteId" type="java.lang.Long" />
+            <field name="employmentType" type="java.lang.String" />
+            <field name="organizationName" type="java.lang.String" />
+            <field name="parentSpouseGovtEmp" type="java.lang.Boolean" />
+            <field name="educationalQualification" type="java.lang.String" />
+            <field name="nonECR" type="java.lang.Boolean" />
+            <field name="aadhaarNumber" type="java.lang.Long" />
+            <field name="fatherGuardianFilePassportNumber" type="java.math.BigDecimal"
+                   scale="3" scaleType="explicit" precision="7" />
+            <field name="fatherGuardiannationalityNotIndian" type="java.lang.Boolean" />
+            <field name="motherGuardianFilePassportNumber" type="java.lang.Long" />
+            <field name="motherGuardiannationalityNotIndian" type="java.lang.Boolean" />
+            <field name="checkTempVisit" type="java.lang.Boolean" />
+            <field name="residingSinceMonth" type="java.lang.String" />
+            <field name="residingSinceYear" type="java.lang.Integer" />
+            <field name="statePresentAdd" type="java.lang.String" />
+            <field name="pin" type="java.lang.Long" />
+            <field name="mobileNumber" type="java.lang.Long" />
+            <field name="telephoneNumber" type="java.lang.Long" />
+            <field name="checkDiplomaaticOfficial" type="java.lang.Boolean" />
+            <field name="tf_DiplOfficialpassportNumber" type="java.lang.Long" />
+            <field name="dDissueDate" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+            <field name="dDExpiryDate" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+            <field name="checkappliedPP" type="java.lang.Boolean" />
+            <field name="fileNumber" type="java.math.BigDecimal" scale="5"
+                   scaleType="explicit" precision="9" />
+            <field name="monthofApplying" type="java.lang.String" />
+            <field name="yearofApplying" type="java.lang.Integer" />
+            <field name="checkCriminal" type="java.lang.Boolean" />
+            <field name="checkOffence5years" type="java.lang.Boolean" />
+            <field name="checkPassportRefused" type="java.lang.Boolean" />
+            <field name="checkImpoundedRevoked" type="java.lang.Boolean" />
+            <field name="tf_passportNumber_revoke" type="java.lang.Long" />
+            <field name="ecDateofIssue" type="java.util.Date" format="yyyy/MM/dd" />
         </schema>
     </outSocket>
     <databaseName value="test" />
     <hostName value="10.130.248.53" />
     <!-- <port value="3306" /> -->
     <jdbcDriver value="Connector/J" />
-    <!--<tableName value="ideaJDBC" />-->
-    <selectQuery value="select * from ideaJDBC where id=10" />
+       <numPartitions value="10">
+           <lowerBound value="110"/>
+           <upperBound value="116"/>
+           <columnName value="yearofApplying"/>
+       </numPartitions>
+       <fetchSize value="100000"/>
+       <!--<extraUrlParams value="userServerPrepStmt=false&amp;rewriteBatchStatements=true"/>-->
+        <tableName value="benchmarking_0001"/>
+       <username value="root" />
+       <password value="root" />
+        
 
-    <username value="root" />
-    <password value="root" />
    </inputs>
 
     <outputs id="output1" xsi:type="ot:textFileDelimited">
         <inSocket  fromComponentId="inputMysql" fromSocketId="out0" id="in0">
             <schema name="outSchema">
-                <field name="id" type="java.lang.Integer" />
-                <field name="name" type="java.lang.String" />
-                <field name="city" type="java.lang.String" />
-                <field name="creditPoint" type="java.lang.Double" />
-                <field name="Deptno" type="java.lang.Integer" />
-                <field name="dob" type="java.util.Date" format="yyyy-MM-dd"/>
-                <field name="dobj" type="java.util.Date" format="yyyy-MM-dd HH:mm:ss" />
-                <field name="extra" type="java.math.BigDecimal" scale="2"
-                       precision="10" scaleType="explicit" />
+                <field name="applyingFor" type="java.lang.String" />
+                <field name="apptype" type="java.lang.String" />
+                <field name="bookletType" type="java.lang.String" />
+                <field name="givennameapplicant" type="java.lang.String" />
+                <field name="surnameapplicant" type="java.lang.String" />
+                <field name="gender" type="java.lang.String" />
+                <field name="alias" type="java.lang.Boolean" />
+                <field name="checkPrevName" type="java.lang.Boolean" />
+                <field name="dt_dob" type="java.util.Date" format="yyyy/MM/dd" />
+                <field name="validityRequired" type="java.lang.Boolean" />
+                <field name="checkPOBOutsideIndia" type="java.lang.Boolean" />
+                <field name="POB" type="java.lang.String" />
+                <field name="country" type="java.lang.String" />
+                <field name="state" type="java.lang.String" />
+                <field name="stateProvince" type="java.lang.String" />
+                <field name="maritalStatus" type="java.lang.String" />
+                <field name="citizenshipOfIndiaBy" type="java.lang.String" />
+                <field name="PAN" type="java.lang.Long" />
+                <field name="voteId" type="java.lang.Long" />
+                <field name="employmentType" type="java.lang.String" />
+                <field name="organizationName" type="java.lang.String" />
+                <field name="parentSpouseGovtEmp" type="java.lang.Boolean" />
+                <field name="educationalQualification" type="java.lang.String" />
+                <field name="nonECR" type="java.lang.Boolean" />
+                <field name="aadhaarNumber" type="java.lang.Long" />
+                <field name="fatherGuardianFilePassportNumber" type="java.math.BigDecimal"
+                       scale="3" scaleType="explicit" precision="7" />
+                <field name="fatherGuardiannationalityNotIndian" type="java.lang.Boolean" />
+                <field name="motherGuardianFilePassportNumber" type="java.lang.Long" />
+                <field name="motherGuardiannationalityNotIndian" type="java.lang.Boolean" />
+                <field name="checkTempVisit" type="java.lang.Boolean" />
+                <field name="residingSinceMonth" type="java.lang.String" />
+                <field name="residingSinceYear" type="java.lang.Integer" />
+                <field name="statePresentAdd" type="java.lang.String" />
+                <field name="pin" type="java.lang.Long" />
+                <field name="mobileNumber" type="java.lang.Long" />
+                <field name="telephoneNumber" type="java.lang.Long" />
+                <field name="checkDiplomaaticOfficial" type="java.lang.Boolean" />
+                <field name="tf_DiplOfficialpassportNumber" type="java.lang.Long" />
+                <field name="dDissueDate" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="dDExpiryDate" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="checkappliedPP" type="java.lang.Boolean" />
+                <field name="fileNumber" type="java.math.BigDecimal" scale="5"
+                       scaleType="explicit" precision="9" />
+                <field name="monthofApplying" type="java.lang.String" />
+                <field name="yearofApplying" type="java.lang.Integer" />
+                <field name="checkCriminal" type="java.lang.Boolean" />
+                <field name="checkOffence5years" type="java.lang.Boolean" />
+                <field name="checkPassportRefused" type="java.lang.Boolean" />
+                <field name="checkImpoundedRevoked" type="java.lang.Boolean" />
+                <field name="tf_passportNumber_revoke" type="java.lang.Long" />
+                <field name="ecDateofIssue" type="java.util.Date" format="yyyy/MM/dd" />
             </schema>
         </inSocket>
         <overWrite value="true"/>
-        <path uri="hydrograph.engine.spark/testData/output/mysql" />
+        <path uri="hydrograph.engine.spark/testData/input/mysql_2l" />
         <delimiter value="," />
         <hasHeader value="false" />
         <charset value="ISO-8859-1" />

--- a/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/MysqlInputDelimitedOutput.xml
+++ b/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/MysqlInputDelimitedOutput.xml
@@ -86,6 +86,7 @@
        </numPartitions>
        <fetchSize value="100000"/>
        <!--<extraUrlParams value="userServerPrepStmt=false&amp;rewriteBatchStatements=true"/>-->
+       <extraUrlParams value="useServerPrepStmts=false,rewriteBatchedStatements=true"/>
         <tableName value="benchmarking_0001"/>
        <username value="root" />
        <password value="root" />

--- a/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/OutputOracleSimple.xml
+++ b/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/OutputOracleSimple.xml
@@ -20,20 +20,59 @@
     <inputs id="input1" batch="0" xsi:type="it:textFileDelimited">
         <outSocket id="out0">
             <schema name="outSchema">
-                <field name="aa" type="java.lang.Integer"/>
-                <field name="bb" type="java.lang.Boolean"/>
-                <field name="cc" type="java.lang.Long"/>
-                <field name="dd" type="java.lang.Float"/>
-                <field name="ee" type="java.lang.Integer"/>
-                <field name="gg" type="java.lang.String"/>
-                <field name="ff" type="java.lang.Double"/>
-                <field name="hh" type="java.util.Date" format="yyyy/MM/dd"/>
-                <field name="ii" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss"/>
-                <field name="jj" type="java.math.BigDecimal" scale="2"
-                       precision="10" scaleType="explicit"/>
+                <field name="APPLYINGFOR" type="java.lang.String" />
+                <field name="APPTYPE" 		type="java.lang.String" />
+                <field name="BOOKLETTYPE" type="java.lang.String" />
+                <field name="GIVENNAMEAPPLICANT" type="java.lang.String" />
+                <field name="SURNAMEAPPLICANT" type="java.lang.String" />
+                <field name="GENDER" type="java.lang.String" />
+                <field name="ALIAS" type="java.lang.String" />
+                <field name="CHECKPREVNAME" type="java.lang.String" />
+                <field name="DT_DOB" type="java.util.Date" format="yyyy/MM/dd" />
+                <field name="VALIDITYREQUIRED" type="java.lang.String" />
+                <field name="CHECKPOBOUTSIDEINDIA" type="java.lang.String" />
+                <field name="POB" type="java.lang.String" />
+                <field name="COUNTRY" type="java.lang.String" />
+                <field name="STATE" type="java.lang.String" />
+                <field name="STATEPROVINCE" type="java.lang.String" />
+                <field name="MARITALSTATUS" type="java.lang.String" />
+                <field name="CITIZENSHIPOFINDIABY" type="java.lang.String" />
+                <field name="PAN" type="java.lang.Long" />
+                <field name="VOTEID" type="java.lang.Long" />
+                <field name="EMPLOYMENTTYPE" type="java.lang.String" />
+                <field name="ORGANIZATIONNAME" type="java.lang.String" />
+                <field name="PARENTSPOUSEGOVTEMP" type="java.lang.String" />
+                <field name="EDUCATIONALQUALIFICATION" type="java.lang.String" />
+                <field name="NONECR" type="java.lang.String" />
+                <field name="AADHAARNUMBER" type="java.lang.Long" />
+                <field name="FATHERGUARDIANFILEPASSNUMBER" type="java.math.BigDecimal" scale="3" scaleType="explicit" precision="7" />
+                <field name="FATHERGUARDIANISNOTINDIAN" type="java.lang.String" />
+                <field name="MOTHERGUARDIANFILEPASSNUMBER" type="java.lang.Long" />
+                <field name="MOTHERGUARDIANISNOTINDIAN" type="java.lang.String" />
+                <field name="CHECKTEMPVISIT" type="java.lang.String" />
+                <field name="RESIDINGSINCEMONTH" type="java.lang.String" />
+                <field name="RESIDINGSINCEYEAR" type="java.lang.Integer" />
+                <field name="STATEPRESENTADD" type="java.lang.String" />
+                <field name="PIN" type="java.lang.Long" />
+                <field name="MOBILENUMBER" type="java.lang.Long" />
+                <field name="TELEPHONENUMBER" type="java.lang.Long" />
+                <field name="CHECKDIPLOMAATICOFFICIAL" type="java.lang.String" />
+                <field name="TF_DIPLOFFICIALPASSPORTNUMBER" type="java.lang.Long" />
+                <field name="DDISSUEDATE" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="DDEXPIRYDATE" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="CHECKAPPLIEDPP" type="java.lang.String" />
+                <field name="FILENUMBER" type="java.math.BigDecimal" scale="5" scaleType="explicit" precision="9" />
+                <field name="MONTHOFAPPLYING" type="java.lang.String" />
+                <field name="YEAROFAPPLYING" type="java.lang.Integer" />
+                <field name="CHECKCRIMINAL" type="java.lang.String" />
+                <field name="CHECKOFFENCE5YEARS" type="java.lang.String" />
+                <field name="CHECKPASSPORTREFUSED" type="java.lang.String" />
+                <field name="CHECKIMPOUNDEDREVOKED" type="java.lang.String" />
+                <field name="TF_PASSPORTNUMBER_REVOKE" type="java.lang.Long" />
+                <field name="ECDATEOFISSUE" type="java.util.Date" format="yyyy/MM/dd" />
             </schema>
         </outSocket>
-        <path uri="hydrograph.engine.spark\testData\inputFiles\RedshiftData.txt"/>
+        <path uri="hydrograph.engine.spark/testData/inputFiles/250mb.txt"/>
         <delimiter value=","/>
         <hasHeader value="false"/>
     </inputs>
@@ -41,39 +80,73 @@
     <outputs id="out oracle" batch="0" xsi:type="ot:oracle">
         <inSocket fromComponentId="input1" fromSocketId="out0" id="in0" type="in">
             <schema name="schema1">
-                <field name="aa" type="java.lang.Short"/>
-                <field name="bb" type="java.lang.Boolean"/>
-                <field name="cc" type="java.lang.Long"/>
-                <field name="dd" type="java.lang.Float"/>
-                <field name="ee" type="java.lang.Integer"/>
-                <field name="gg" type="java.lang.String"/>
-                <field name="ff" type="java.lang.Double"/>
-                <field name="hh" type="java.util.Date" format="yyyy-MM-dd"/>
-                <field name="ii" type="java.util.Date" format="yyyy-MM-dd HH:mm:ss"/>
-                <field name="jj" type="java.math.BigDecimal" scale="2"
-                       precision="10" scaleType="explicit"/>
+                <field name="APPLYINGFOR" type="java.lang.String" />
+                <field name="APPTYPE" 		type="java.lang.String" />
+                <field name="BOOKLETTYPE" type="java.lang.String" />
+                <field name="GIVENNAMEAPPLICANT" type="java.lang.String" />
+                <field name="SURNAMEAPPLICANT" type="java.lang.String" />
+                <field name="GENDER" type="java.lang.String" />
+                <field name="ALIAS" type="java.lang.String" />
+                <field name="CHECKPREVNAME" type="java.lang.String" />
+                <field name="DT_DOB" type="java.util.Date" format="yyyy/MM/dd" />
+                <field name="VALIDITYREQUIRED" type="java.lang.String" />
+                <field name="CHECKPOBOUTSIDEINDIA" type="java.lang.String" />
+                <field name="POB" type="java.lang.String" />
+                <field name="COUNTRY" type="java.lang.String" />
+                <field name="STATE" type="java.lang.String" />
+                <field name="STATEPROVINCE" type="java.lang.String" />
+                <field name="MARITALSTATUS" type="java.lang.String" />
+                <field name="CITIZENSHIPOFINDIABY" type="java.lang.String" />
+                <field name="PAN" type="java.lang.Long" />
+                <field name="VOTEID" type="java.lang.Long" />
+                <field name="EMPLOYMENTTYPE" type="java.lang.String" />
+                <field name="ORGANIZATIONNAME" type="java.lang.String" />
+                <field name="PARENTSPOUSEGOVTEMP" type="java.lang.String" />
+                <field name="EDUCATIONALQUALIFICATION" type="java.lang.String" />
+                <field name="NONECR" type="java.lang.String" />
+                <field name="AADHAARNUMBER" type="java.lang.Long" />
+                <field name="FATHERGUARDIANFILEPASSNUMBER" type="java.math.BigDecimal" scale="3" scaleType="explicit" precision="7" />
+                <field name="FATHERGUARDIANISNOTINDIAN" type="java.lang.String" />
+                <field name="MOTHERGUARDIANFILEPASSNUMBER" type="java.lang.Long" />
+                <field name="MOTHERGUARDIANISNOTINDIAN" type="java.lang.String" />
+                <field name="CHECKTEMPVISIT" type="java.lang.String" />
+                <field name="RESIDINGSINCEMONTH" type="java.lang.String" />
+                <field name="RESIDINGSINCEYEAR" type="java.lang.Integer" />
+                <field name="STATEPRESENTADD" type="java.lang.String" />
+                <field name="PIN" type="java.lang.Long" />
+                <field name="MOBILENUMBER" type="java.lang.Long" />
+                <field name="TELEPHONENUMBER" type="java.lang.Long" />
+                <field name="CHECKDIPLOMAATICOFFICIAL" type="java.lang.String" />
+                <field name="TF_DIPLOFFICIALPASSPORTNUMBER" type="java.lang.Long" />
+                <field name="DDISSUEDATE" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="DDEXPIRYDATE" type="java.util.Date" format="yyyy/MM/dd HH:mm:ss" />
+                <field name="CHECKAPPLIEDPP" type="java.lang.String" />
+                <field name="FILENUMBER" type="java.math.BigDecimal" scale="5" scaleType="explicit" precision="9" />
+                <field name="MONTHOFAPPLYING" type="java.lang.String" />
+                <field name="YEAROFAPPLYING" type="java.lang.Integer" />
+                <field name="CHECKCRIMINAL" type="java.lang.String" />
+                <field name="CHECKOFFENCE5YEARS" type="java.lang.String" />
+                <field name="CHECKPASSPORTREFUSED" type="java.lang.String" />
+                <field name="CHECKIMPOUNDEDREVOKED" type="java.lang.String" />
+                <field name="TF_PASSPORTNUMBER_REVOKE" type="java.lang.Long" />
+                <field name="ECDATEOFISSUE" type="java.util.Date" format="yyyy/MM/dd" />
             </schema>
         </inSocket>
         <sid value="PRACTICE"/>
         <hostName value="DBDEVSRV"/>
         <port value="1521"/>
         <driverType value="thin"/>
-        <tableName value="testingTableAllTablesbatchSize"/>
+        <tableName value="newTable1125"/>
         <userName value="htcd"/>
         <password value="Bitwise2017"/>
+        <chunkSize value="100000"/>
         <loadType>
-            <newTable>
-                <primaryKeys>
-                    <field name="aa"/>
-                </primaryKeys>
-            </newTable>
+            <newTable></newTable>
+
             <!--<truncateLoad />-->
             <!--<Insert/>-->
         </loadType>
         <!--<schemaName value="htcd"/>-->
         <!--<chunkSize value="2"/>-->
-        <runtimeProperties>
-            <property name="batchsize" value="9"/>
-        </runtimeProperties>
     </outputs>
 </p:graph>

--- a/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/teradata/InputTeradataDelimitedOutput.xml
+++ b/hydrograph.engine/hydrograph.engine.spark/testData/XMLFiles/teradata/InputTeradataDelimitedOutput.xml
@@ -1,32 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License
- -->
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<p:graph name="DelimitedInputAndTeradataOutput" xmlns:p="hydrograph/engine/jaxb/main"
+<p:graph name="TeradataInputAndDelimitedOutput" xmlns:p="hydrograph/engine/jaxb/main"
          xmlns:it="hydrograph/engine/jaxb/inputtypes" xmlns:ot="hydrograph/engine/jaxb/outputtypes"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="hydrograph/engine/jaxb/main ../../../../hydrograph.engine.core/src/main/resources/newxmlschema/main/main.xsd  ">
+         xsi:schemaLocation="hydrograph/engine/jaxb/main ../../../hydrograph.engine.core/src/main/resources/newxmlschema/main/main.xsd">
 
-    <inputs id="input1" batch="0" xsi:type="it:textFileDelimited">
+
+    <inputs id="inputTeradata" batch="0" xsi:type="it:teradata">
         <outSocket id="out0">
-            <schema name="outSchema">
+            <schema name="schema1">
                 <field name="applyingFor" type="java.lang.String" />
                 <field name="apptype" type="java.lang.String" />
                 <field name="bookletType" type="java.lang.String" />
                 <field name="givennameapplicant" type="java.lang.String" />
                 <field name="surnameapplicant" type="java.lang.String" />
                 <field name="gender" type="java.lang.String" />
-                <field name="alias1" type="java.lang.Boolean" />
+                <field name="alias1" type="java.lang.Integer" />
                 <field name="checkPrevName" type="java.lang.Boolean" />
                 <field name="dt_dob" type="java.util.Date" format="yyyy/MM/dd" />
                 <field name="validityRequired" type="java.lang.Boolean" />
@@ -74,21 +75,32 @@
                 <field name="ecDateofIssue" type="java.util.Date" format="yyyy/MM/dd" />
             </schema>
         </outSocket>
-        <path uri="hydrograph.engine.spark/testData/inputFiles/250mb.txt" />
-        <delimiter value="," />
-        <hasHeader value="false" />
+        <databaseName value="hydrograph_db" />
+        <hostName value="10.130.250.235" />
+        <port value="1025" />
+        <jdbcDriver value="TeraJDBC4" />
+        <!--<numPartitions value="7">
+            <lowerBound value="110"/>
+            <upperBound value="116"/>
+            <columnName value="yearofApplying"/>
+        </numPartitions>-->
+        <fetchSize value="100000"/>
+        <tableName value="benchmarking_00100" />
+        <exportOptions value="FASTEXPORT"/>
+        <username value="hydrograph1" />
+        <password value="teradata" />
     </inputs>
 
-    <outputs id="outputTeradata" xsi:type="ot:teradata">
-        <inSocket fromComponentId="input1" fromSocketId="out0" id="in0">
-            <schema name="schema1">
+    <outputs id="output1" xsi:type="ot:textFileDelimited">
+        <inSocket  fromComponentId="inputTeradata" fromSocketId="out0" id="in0">
+            <schema name="outSchema">
                 <field name="applyingFor" type="java.lang.String" />
                 <field name="apptype" type="java.lang.String" />
                 <field name="bookletType" type="java.lang.String" />
                 <field name="givennameapplicant" type="java.lang.String" />
                 <field name="surnameapplicant" type="java.lang.String" />
                 <field name="gender" type="java.lang.String" />
-                <field name="alias1" type="java.lang.Boolean" />
+                <field name="alias1" type="java.lang.Integer" />
                 <field name="checkPrevName" type="java.lang.Boolean" />
                 <field name="dt_dob" type="java.util.Date" format="yyyy/MM/dd" />
                 <field name="validityRequired" type="java.lang.Boolean" />
@@ -136,25 +148,10 @@
                 <field name="ecDateofIssue" type="java.util.Date" format="yyyy/MM/dd" />
             </schema>
         </inSocket>
-
-        <databaseName value="hydrograph_db" />
-        <hostName value="10.130.250.235" />
-        <port value="1025" />
-        <jdbcDriver value="TeraJDBC4" />
-        <tableName value="benchmarking_00100" />
-        <username value="hydrograph1" />
-        <password value="teradata" />
-        <chunkSize value="100000"/>
-        <loadUtilityType value="DEFAULT"/>
-
-
-            <loadType>
-               <newTable></newTable>
-            </loadType>
-
-            <!--<Insert/>-->
-            <!-- <truncateLoad/>-->
-
-
+        <overWrite value="true"/>
+        <path uri="hydrograph.engine.spark/testData/input/teradata_delimited" />
+        <delimiter value="," />
+        <hasHeader value="false" />
+        <charset value="ISO-8859-1" />
     </outputs>
 </p:graph>


### PR DESCRIPTION
- Made core level and component level changes to the database components namely Mysql, Oracle and Teradata.  

- Added partitioning feature and provisions for adding batch and fetch sizes on an individual basis. The batch and fetch sizes are the rows that can be uploaded to a databases or downloaded from a database respectively per network round trips. A moderate batch size or fetch size can reduce the network trips since they carry more number of rows from source to destination over the network. 

- Provisions to add extra url parameters which will be appended to the url in order to gain performance benefit or any other requirements the user may have with the respective databases.