### PR TITLE
Run configuration Window Default radio button selection

### DIFF
--- a/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/Release_Notes_April_2017.txt
+++ b/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/Release_Notes_April_2017.txt
@@ -10,3 +10,5 @@ Sr.No. <GitHub Issue #>  - [fixed by] - description
 1. <> - [Vibhor Tyagi] - Subjob issue : Subjob was not getting imported.
 2. <> - [Prateem] - .job file size mismatch when components from one file copied to other file.
 3. <> - [Pooja Yadav] - Count field of Limit component is converting a negative value into parameterization format.
+4. <> - [Pooja Yadav] - Run Config : - Tool shows error for unused field.
+5. <> - [Pooja Yadav] - Run configuration dialog defaults to ‘Remote’ and ‘Key file’. It should ideally be ‘Local’ and ‘Password’.

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/handlers/RunConfigHandler.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/handlers/RunConfigHandler.java
@@ -13,14 +13,15 @@
 
  
 package hydrograph.ui.propertywindow.handlers;
+import hydrograph.ui.logging.factory.LogFactory;
 import hydrograph.ui.propertywindow.runconfig.RunConfigDialog;
-
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.IHandler;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Display;
+import org.slf4j.Logger;
 
 
 /**
@@ -31,7 +32,7 @@ import org.eclipse.swt.widgets.Display;
 
 public class RunConfigHandler extends AbstractHandler implements IHandler {
 
-
+	private Logger logger = LogFactory.INSTANCE.getLogger(RunConfigHandler.class);
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		 
@@ -40,9 +41,11 @@ public class RunConfigHandler extends AbstractHandler implements IHandler {
 				runConfig.open();
 			}catch(IllegalArgumentException e){
 				MessageDialog.openWarning(Display.getDefault().getActiveShell(), "Warning", e.getMessage());
+				logger.error("Failed to start run configuration : ",e);
 			}
 			catch(Exception e){
 				MessageDialog.openWarning(Display.getDefault().getActiveShell(), "Warning", "Please save the graph before setting the run configuration.");
+				logger.error("Failed to start run configuration : ",e);
 			}
 		return null;
 	}

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
@@ -394,7 +394,7 @@ public class RunConfigDialog extends Dialog {
 			if(hydrographSecureStorageRunDialogHostNode!=null){
 				String password=hydrographSecureStorageRunDialogHostNode.get(txtUserName.getText(), "");
 				txtPassword.setText(password);
-				if(radioPassword.isEnabled()){
+				if(radioPassword.isEnabled() && !txtPassword.isEnabled()){
 					textPasswordListener.getErrorDecoration().hide();
 				}
 				if(!StringUtils.isBlank(password)){
@@ -583,7 +583,7 @@ public class RunConfigDialog extends Dialog {
 		if(StringUtils.equals(buildProps.getProperty(USE_PASSWORD_AUTHENTICATION), TRUE) || StringUtils.isBlank(txtKeyFile.getText())){
 			togglePasswordAndKeyFile(true);
 			keyFileListener.getErrorDecoration().hide();
-			if(StringUtils.isBlank(txtKeyFile.getText())){
+			if(StringUtils.isBlank(txtPassword.getText())){
 				textPasswordListener.getErrorDecoration().show();
 			}
 		}

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
@@ -552,14 +552,14 @@ public class RunConfigDialog extends Dialog {
 	}
 
 	private void populateTextBoxes(Enumeration propertyNames) {
-		if (StringUtils.equals(buildProps.getProperty(LOCAL_MODE), TRUE)) {
-			btnLocalMode.setSelection(true);
-			btnRemoteMode.setSelection(false);
-			hideRemoteRunDetailsHolderComposite();
-		} else {
+		if (StringUtils.equals(buildProps.getProperty(REMOTE_MODE), TRUE)) {
 			btnRemoteMode.setSelection(true);
 			btnLocalMode.setSelection(false);
 			showRemoteRunDetailsHolderComposite();
+		} else {
+			btnLocalMode.setSelection(true);
+			btnRemoteMode.setSelection(false);
+			hideRemoteRunDetailsHolderComposite();
 		}
 		txtEdgeNode.setText(getBuildProperty(HOST));
 		txtUserName.setText(getBuildProperty(USER_NAME));
@@ -572,7 +572,7 @@ public class RunConfigDialog extends Dialog {
 			viewDataCheckBox.setSelection(true);
 			txtBasePath.setEnabled(true);
 		}
-		if(StringUtils.equals(buildProps.getProperty(USE_PASSWORD_AUTHENTICATION), TRUE)){
+		if(StringUtils.equals(buildProps.getProperty(USE_PASSWORD_AUTHENTICATION), TRUE) || StringUtils.isBlank(txtKeyFile.getText())){
 			togglePasswordAndKeyFile(true);
 			keyFileListener.getErrorDecoration().hide();
 			if(StringUtils.isBlank(txtKeyFile.getText())){

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
@@ -580,7 +580,7 @@ public class RunConfigDialog extends Dialog {
 			viewDataCheckBox.setSelection(true);
 			txtBasePath.setEnabled(true);
 		}
-		if(StringUtils.equals(buildProps.getProperty(USE_PASSWORD_AUTHENTICATION), TRUE) || StringUtils.isBlank(txtKeyFile.getText())){
+		if(StringUtils.equals(buildProps.getProperty(USE_PASSWORD_AUTHENTICATION), TRUE) ){
 			togglePasswordAndKeyFile(true);
 			keyFileListener.getErrorDecoration().hide();
 			if(StringUtils.isBlank(txtPassword.getText())){

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
@@ -500,7 +500,7 @@ public class RunConfigDialog extends Dialog {
 		txtUserName.setText(txtUserName.getText());	
 		txtPassword.setText(txtPassword.getText());
 		txtKeyFile.setText(txtKeyFile.getText());
-		if(radioKeyFile.isEnabled()){
+		if(radioKeyFile.isEnabled() && txtKeyFile.isEnabled()){
 			textPasswordListener.getErrorDecoration().hide();
 		}else{
 			keyFileListener.getErrorDecoration().hide();
@@ -518,11 +518,6 @@ public class RunConfigDialog extends Dialog {
 		txtUserName.setText(txtUserName.getText());
 		txtPassword.setText(txtPassword.getText());
 		txtKeyFile.setText(txtKeyFile.getText());
-		if(radioKeyFile.isEnabled()){
-			textPasswordListener.getErrorDecoration().hide();
-		}else{
-			keyFileListener.getErrorDecoration().hide();
-		}
 		serverDetailsGroup.setVisible(false);
 		remotePathConfigGroup.setVisible(false);
 	}

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
@@ -494,9 +494,12 @@ public class RunConfigDialog extends Dialog {
 		Point shellSize = getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT);
 		getShell().setSize(shellSize);
 		txtEdgeNode.setText(txtEdgeNode.getText());
-		txtUserName.setText(txtUserName.getText());
-		txtPassword.setText(txtPassword.getText());
-		txtKeyFile.setText(txtKeyFile.getText());
+		txtUserName.setText(txtUserName.getText());		
+		if(radioPassword.isEnabled()){
+			txtPassword.setText(txtPassword.getText());
+		}else{
+			txtKeyFile.setText(txtKeyFile.getText());
+		}
 		serverDetailsGroup.setVisible(true);
 		remotePathConfigGroup.setVisible(true);
 	}
@@ -508,8 +511,11 @@ public class RunConfigDialog extends Dialog {
 		getShell().setSize(newShellSize);
 		txtEdgeNode.setText(txtEdgeNode.getText());
 		txtUserName.setText(txtUserName.getText());
-		txtPassword.setText(txtPassword.getText());
-		txtKeyFile.setText(txtKeyFile.getText());
+		if(radioPassword.isEnabled()){
+			txtPassword.setText(txtPassword.getText());
+		}else{
+			txtKeyFile.setText(txtKeyFile.getText());
+		}
 		serverDetailsGroup.setVisible(false);
 		remotePathConfigGroup.setVisible(false);
 	}

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/runconfig/RunConfigDialog.java
@@ -394,6 +394,9 @@ public class RunConfigDialog extends Dialog {
 			if(hydrographSecureStorageRunDialogHostNode!=null){
 				String password=hydrographSecureStorageRunDialogHostNode.get(txtUserName.getText(), "");
 				txtPassword.setText(password);
+				if(radioPassword.isEnabled()){
+					textPasswordListener.getErrorDecoration().hide();
+				}
 				if(!StringUtils.isBlank(password)){
 					chkbtnSavePassword.setSelection(true);
 				}else{
@@ -494,11 +497,13 @@ public class RunConfigDialog extends Dialog {
 		Point shellSize = getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT);
 		getShell().setSize(shellSize);
 		txtEdgeNode.setText(txtEdgeNode.getText());
-		txtUserName.setText(txtUserName.getText());		
-		if(radioPassword.isEnabled()){
-			txtPassword.setText(txtPassword.getText());
+		txtUserName.setText(txtUserName.getText());	
+		txtPassword.setText(txtPassword.getText());
+		txtKeyFile.setText(txtKeyFile.getText());
+		if(radioKeyFile.isEnabled()){
+			textPasswordListener.getErrorDecoration().hide();
 		}else{
-			txtKeyFile.setText(txtKeyFile.getText());
+			keyFileListener.getErrorDecoration().hide();
 		}
 		serverDetailsGroup.setVisible(true);
 		remotePathConfigGroup.setVisible(true);
@@ -511,10 +516,12 @@ public class RunConfigDialog extends Dialog {
 		getShell().setSize(newShellSize);
 		txtEdgeNode.setText(txtEdgeNode.getText());
 		txtUserName.setText(txtUserName.getText());
-		if(radioPassword.isEnabled()){
-			txtPassword.setText(txtPassword.getText());
+		txtPassword.setText(txtPassword.getText());
+		txtKeyFile.setText(txtKeyFile.getText());
+		if(radioKeyFile.isEnabled()){
+			textPasswordListener.getErrorDecoration().hide();
 		}else{
-			txtKeyFile.setText(txtKeyFile.getText());
+			keyFileListener.getErrorDecoration().hide();
 		}
 		serverDetailsGroup.setVisible(false);
 		remotePathConfigGroup.setVisible(false);


### PR DESCRIPTION
Issue : Need to change default selection of radio buttons in run configuration window 
           Error Decorator of key File is visible even if field is in disable mode.

Solution : Changed default selection of radio buttons in run configuration window.
                error decorator of disabled fields are made hidden.