### PR TITLE
Implemented safe and strict property in InputFileCsvUnivocity component

### DIFF
--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputFileCsvUnivocityComponent.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputFileCsvUnivocityComponent.scala
@@ -1,15 +1,15 @@
-/*******************************************************************************
- * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+/** *****************************************************************************
+  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  * http://www.apache.org/licenses/LICENSE-2.0
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  * ******************************************************************************/
 package hydrograph.engine.spark.components
 
 import hydrograph.engine.core.component.entity.InputFileDelimitedEntity
@@ -29,12 +29,11 @@ import scala.collection.JavaConverters._
   */
 class InputFileCsvUnivocityComponent(iFileDelimitedEntity: InputFileDelimitedEntity, iComponentsParams: BaseComponentParams)
   extends InputComponentBase with Serializable {
-  private val LOG:Logger = LoggerFactory.getLogger(classOf[InputFileCsvUnivocityComponent])
+  private val LOG: Logger = LoggerFactory.getLogger(classOf[InputFileCsvUnivocityComponent])
+
   override def createComponent(): Map[String, DataFrame] = {
     LOG.trace("In method createComponent()")
     val schemaCreator = SchemaCreator(iFileDelimitedEntity)
-//    val dateFormats=schemaCreator.getDateFormats()
-//    val schemaField = schemaCreator.makeSchema
     try {
       val df = iComponentsParams.getSparkSession().read
         .option("delimiter", iFileDelimitedEntity.getDelimiter)
@@ -42,7 +41,10 @@ class InputFileCsvUnivocityComponent(iFileDelimitedEntity: InputFileDelimitedEnt
         .option("header", iFileDelimitedEntity.isHasHeader)
         .option("charset", iFileDelimitedEntity.getCharset)
         .option("safe", iFileDelimitedEntity.isSafe)
-        .option("strict", iFileDelimitedEntity.isStrict)
+        .option("mode", iFileDelimitedEntity.isStrict match {
+          case true => "FAILFAST"
+          case false => "PERMISSIVE"
+        })
         .option("dateFormats", schemaCreator.getDateFormats)
         .option("componentId", iFileDelimitedEntity.getComponentId)
         .schema(schemaCreator.makeSchema)
@@ -50,11 +52,11 @@ class InputFileCsvUnivocityComponent(iFileDelimitedEntity: InputFileDelimitedEnt
         .load(iFileDelimitedEntity.getPath)
 
       val key = iFileDelimitedEntity.getOutSocketList.get(0).getSocketId
-      LOG.info("Created Input File Delimited Component "+ iFileDelimitedEntity.getComponentId
-        + " in Batch "+ iFileDelimitedEntity.getBatch +" with output socket " + key
-        + " and path "  + iFileDelimitedEntity.getPath)
-      LOG.debug("Component Id: '"+ iFileDelimitedEntity.getComponentId
-        +"' in Batch: " + iFileDelimitedEntity.getBatch
+      LOG.info("Created Input File Delimited Component " + iFileDelimitedEntity.getComponentId
+        + " in Batch " + iFileDelimitedEntity.getBatch + " with output socket " + key
+        + " and path " + iFileDelimitedEntity.getPath)
+      LOG.debug("Component Id: '" + iFileDelimitedEntity.getComponentId
+        + "' in Batch: " + iFileDelimitedEntity.getBatch
         + " having schema: [ " + iFileDelimitedEntity.getFieldsList.asScala.mkString(",")
         + " ] with delimiter: " + iFileDelimitedEntity.getDelimiter
         + " and quote: " + iFileDelimitedEntity.getQuote
@@ -63,9 +65,9 @@ class InputFileCsvUnivocityComponent(iFileDelimitedEntity: InputFileDelimitedEnt
       Map(key -> df)
     } catch {
 
-      case e : Exception =>
-        LOG.error("Error in Input File Delimited Component "+ iFileDelimitedEntity.getComponentId, e)
-        throw new RuntimeException("Error in Input File Delimited Component "+ iFileDelimitedEntity.getComponentId, e)
+      case e: Exception =>
+        LOG.error("Error in Input File Delimited Component " + iFileDelimitedEntity.getComponentId, e)
+        throw new RuntimeException("Error in Input File Delimited Component " + iFileDelimitedEntity.getComponentId, e)
     }
 
   }

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/OutputFileCsvUnivocityComponent.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/OutputFileCsvUnivocityComponent.scala
@@ -1,15 +1,15 @@
-/*******************************************************************************
- * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+/** *****************************************************************************
+  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  * http://www.apache.org/licenses/LICENSE-2.0
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  * ******************************************************************************/
 package hydrograph.engine.spark.components
 
 import hydrograph.engine.core.component.entity.OutputFileDelimitedEntity
@@ -29,39 +29,42 @@ import scala.collection.JavaConverters._
   */
 class OutputFileCsvUnivocityComponent(outputFileDelimitedEntity: OutputFileDelimitedEntity, cp:
 BaseComponentParams) extends SparkFlow with Serializable {
-  private val LOG:Logger = LoggerFactory.getLogger(classOf[OutputFileCsvUnivocityComponent])
+  private val LOG: Logger = LoggerFactory.getLogger(classOf[OutputFileCsvUnivocityComponent])
 
   override def execute() = {
     LOG.trace("In method execute()")
     val schemaCreator = SchemaCreator(outputFileDelimitedEntity)
 
-   try {
-     cp.getDataFrame().select(schemaCreator.createSchema(): _*).write
-       .option("delimiter", outputFileDelimitedEntity.getDelimiter)
-       .option("quote", outputFileDelimitedEntity.getQuote)
-       .option("header", outputFileDelimitedEntity.getHasHeader)
-       .option("charset", outputFileDelimitedEntity.getCharset)
-       .option("strict", outputFileDelimitedEntity.isStrict)
-       .option("safe", outputFileDelimitedEntity.getSafe)
-       .option("dateFormats", schemaCreator.getDateFormats)
-       .option("codec", SchemaUtils().getCodec(outputFileDelimitedEntity))
-       .mode(if (outputFileDelimitedEntity.isOverWrite ) SaveMode.Overwrite else SaveMode.ErrorIfExists)
-       .format("hydrograph.engine.spark.datasource.csvwithunivocity.CSVFileFormat")
-       .save(outputFileDelimitedEntity.getPath)
-   } catch {
-     case e: AnalysisException if (e.getMessage().matches("(.*)cannot resolve(.*)given input columns(.*)"))=>
-       LOG.error("Error in Output File Delimited Component "+ outputFileDelimitedEntity.getComponentId, e)
-       throw new RuntimeException("Error in Output File Delimited Component '"
-         + outputFileDelimitedEntity.getComponentId+"' ", e )
-     case e:Exception =>
-       LOG.error("Error in Output File Delimited Component "+ outputFileDelimitedEntity.getComponentId, e)
-       throw new RuntimeException("Error in Output File Delimited Component '"
-         + outputFileDelimitedEntity.getComponentId +"' "+ e)
-   }
-    LOG.info("Created Output File Delimited Component "+ outputFileDelimitedEntity.getComponentId
-      + " in Batch "+ outputFileDelimitedEntity.getBatch +" with path " + outputFileDelimitedEntity.getPath)
-    LOG.debug("Component Id: '"+ outputFileDelimitedEntity.getComponentId
-      +"' in Batch: " + outputFileDelimitedEntity.getBatch
+    try {
+      cp.getDataFrame().select(schemaCreator.createSchema(): _*).write
+        .option("delimiter", outputFileDelimitedEntity.getDelimiter)
+        .option("quote", outputFileDelimitedEntity.getQuote)
+        .option("header", outputFileDelimitedEntity.getHasHeader)
+        .option("charset", outputFileDelimitedEntity.getCharset)
+        .option("mode", outputFileDelimitedEntity.isStrict match {
+          case true => "FAILFAST"
+          case false => "PERMISSIVE"
+        })
+        .option("safe", outputFileDelimitedEntity.getSafe)
+        .option("dateFormats", schemaCreator.getDateFormats)
+        .option("codec", SchemaUtils().getCodec(outputFileDelimitedEntity))
+        .mode(if (outputFileDelimitedEntity.isOverWrite) SaveMode.Overwrite else SaveMode.ErrorIfExists)
+        .format("hydrograph.engine.spark.datasource.csvwithunivocity.CSVFileFormat")
+        .save(outputFileDelimitedEntity.getPath)
+    } catch {
+      case e: AnalysisException if (e.getMessage().matches("(.*)cannot resolve(.*)given input columns(.*)")) =>
+        LOG.error("Error in Output File Delimited Component " + outputFileDelimitedEntity.getComponentId, e)
+        throw new RuntimeException("Error in Output File Delimited Component '"
+          + outputFileDelimitedEntity.getComponentId + "' ", e)
+      case e: Exception =>
+        LOG.error("Error in Output File Delimited Component " + outputFileDelimitedEntity.getComponentId, e)
+        throw new RuntimeException("Error in Output File Delimited Component '"
+          + outputFileDelimitedEntity.getComponentId + "' " + e)
+    }
+    LOG.info("Created Output File Delimited Component " + outputFileDelimitedEntity.getComponentId
+      + " in Batch " + outputFileDelimitedEntity.getBatch + " with path " + outputFileDelimitedEntity.getPath)
+    LOG.debug("Component Id: '" + outputFileDelimitedEntity.getComponentId
+      + "' in Batch: " + outputFileDelimitedEntity.getBatch
       + " having schema: [ " + outputFileDelimitedEntity.getFieldsList.asScala.mkString(",")
       + " ] with delimiter: " + outputFileDelimitedEntity.getDelimiter + " and quote: " + outputFileDelimitedEntity.getQuote
       + " strict as " + outputFileDelimitedEntity.isStrict + " safe as " + outputFileDelimitedEntity.getSafe

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/datasource/csvwithunivocity/CSVFileFormat.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/datasource/csvwithunivocity/CSVFileFormat.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.execution.datasources.HadoopFileLinesReader
 
 /**
   * The Class CSVFileFormat.

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/datasource/csvwithunivocity/CSVParser.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/datasource/csvwithunivocity/CSVParser.scala
@@ -77,7 +77,7 @@ private class LineCsvWriter(params: CSVOptions, headers: Seq[String])  {
 
   private var buffer = new ByteArrayOutputStream()
   private var writer = new CsvWriter(
-    new OutputStreamWriter(buffer, StandardCharsets.UTF_8),
+    new OutputStreamWriter(buffer, params.charset),
     writerSettings)
 
   def writeRow(row: Seq[String], includeHeader: Boolean): Unit = {
@@ -89,10 +89,10 @@ private class LineCsvWriter(params: CSVOptions, headers: Seq[String])  {
 
   def flush(): String = {
     writer.close()
-    val lines = buffer.toString.stripLineEnd
+    val lines = buffer.toString(params.charset).stripLineEnd
     buffer = new ByteArrayOutputStream()
     writer = new CsvWriter(
-      new OutputStreamWriter(buffer, StandardCharsets.UTF_8),
+      new OutputStreamWriter(buffer, params.charset),
       writerSettings)
     lines
   }

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/datasource/csvwithunivocity/CSVTypeCast.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/datasource/csvwithunivocity/CSVTypeCast.scala
@@ -245,8 +245,10 @@ private object CSVTypeCast {
             case options.negativeInf => Float.NegativeInfinity
             case options.positiveInf => Float.PositiveInfinity
             case _ =>
-              Try(datum.toFloat)
-                .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())
+              datum.toFloat
+
+              /*Try(datum.toFloat)
+                .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())*/
           }
         case _: DoubleType =>
           datum match {
@@ -254,8 +256,9 @@ private object CSVTypeCast {
             case options.negativeInf => Double.NegativeInfinity
             case options.positiveInf => Double.PositiveInfinity
             case _ =>
-              Try(datum.toDouble)
-                .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
+              datum.toDouble
+              /*Try(datum.toDouble)
+                .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())*/
           }
         case _: BooleanType => datum.toBoolean
         case dt: DecimalType =>

--- a/hydrograph.engine/hydrograph.engine.spark/src/test/scala/hydrograph/engine/spark/components/InputFileCsvUnivocityComponentTest.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/test/scala/hydrograph/engine/spark/components/InputFileCsvUnivocityComponentTest.scala
@@ -1,0 +1,277 @@
+package hydrograph.engine.spark.components
+
+import java.util
+
+import hydrograph.engine.core.component.entity.InputFileDelimitedEntity
+import hydrograph.engine.core.component.entity.elements.{OutSocket, SchemaField}
+import hydrograph.engine.spark.components.platform.BaseComponentParams
+import org.apache.spark.SparkException
+import org.apache.spark.sql._
+import org.junit.{Assert, Before, Test}
+
+/**
+  * The Class InputFileCsvUnivocityComponent.
+  *
+  * @author Bitwise
+  *
+  */
+class InputFileCsvUnivocityComponentTest {
+
+   var inputFileDelimitedEntity: InputFileDelimitedEntity = new InputFileDelimitedEntity
+  var cp: BaseComponentParams = new BaseComponentParams
+
+  @Before
+  def executedBeforeEachTestCase() {
+
+    val sparkSession = SparkSession.builder()
+      .master("local")
+      .appName("testing")
+      .config("spark.sql.shuffle.partitions", "1")
+      .config("spark.sql.warehouse.dir", "file:///tmp")
+      .getOrCreate()
+
+    cp.setSparkSession(sparkSession)
+
+    val sf1 = new SchemaField("ID", "java.lang.Short");
+
+    val sf2 = new SchemaField("Name", "java.lang.String");
+
+    val sf3 = new SchemaField("Role", "java.lang.String");
+
+    val sf4 = new SchemaField("Address", "java.lang.String");
+
+    val sf5 = new SchemaField("DOJ", "java.util.Date");
+    sf5.setFieldFormat("yyyy-MM-dd")
+
+    val sf6 = new SchemaField("DOR", "java.util.Date");
+    sf6.setFieldFormat("yyyy/MM/dd HH:mm:ss.SSS")
+
+    val sf7 = new SchemaField("Sal", "java.math.BigDecimal");
+    sf7.setFieldPrecision(13)
+    sf7.setFieldScale(3)
+
+    val sf8 = new SchemaField("Rating", "java.lang.Integer");
+
+    val fieldList: util.List[SchemaField] = new util.ArrayList[SchemaField]();
+    fieldList.add(sf1)
+    fieldList.add(sf2)
+    fieldList.add(sf3)
+    fieldList.add(sf4)
+    fieldList.add(sf5)
+    fieldList.add(sf6)
+    fieldList.add(sf7)
+    fieldList.add(sf8)
+
+    inputFileDelimitedEntity.setFieldsList(fieldList)
+
+    val outSockets = new util.ArrayList[OutSocket]();
+    outSockets.add(new OutSocket("outSocket"));
+
+    inputFileDelimitedEntity.setComponentId("inpuFileDelimited");
+    inputFileDelimitedEntity.setOutSocketList(outSockets)
+    inputFileDelimitedEntity.setCharset("UTF-8")
+    inputFileDelimitedEntity.setDelimiter(",")
+    inputFileDelimitedEntity.setQuote("\"")
+    inputFileDelimitedEntity.setHasHeader(false)
+  }
+
+  /**
+   * Test case for correct schema
+   */
+
+  @Test
+  def itShouldCheckStrictAndSafeForCorrectInputFormatAndCorrectLength(): Unit = {
+
+    //Given
+
+    val inputPathCase0: String = "testData/inputFiles/employees.txt"
+
+    inputFileDelimitedEntity.setStrict(true)
+    inputFileDelimitedEntity.setSafe(false)
+    inputFileDelimitedEntity.setPath(inputPathCase0)
+
+    //when
+
+    val df: Map[String, DataFrame] = new InputFileCsvUnivocityComponent(inputFileDelimitedEntity, cp).createComponent()
+
+    //Then
+
+    val expectedSize: Int = 8
+    val expectedResult: String = "[3,Hemant,Programmer,BBSR,OD,2015-06-25,2016-06-25 02:02:02.325,50.300,3]"
+    Assert.assertEquals(expectedSize, df.get("outSocket").get.first().size)
+    Assert.assertEquals(expectedResult, df.get("outSocket").get.first().toString())
+  }
+
+  @Test(expected = classOf[SparkException])
+  def itShouldThrowExceptionForIncorrectDataTypeWhenSafeFalse(): Unit = {
+
+    //Given
+
+    val inputPathCase1: String = "testData/inputFiles/employees1.txt"
+
+    inputFileDelimitedEntity.setStrict(true)
+    inputFileDelimitedEntity.setSafe(false)
+    inputFileDelimitedEntity.setPath(inputPathCase1)
+
+    //when
+
+    val df: Map[String, DataFrame] = new InputFileCsvUnivocityComponent(inputFileDelimitedEntity, cp).createComponent()
+
+    //Then
+
+    val expectedSize: Int = 8
+    val expectedResult: String = "[3,Hemant,68.36,BBSR,OD,2015-06-25,2016-06-25 02:02:02.325,50.300,null]"
+    Assert.assertEquals(expectedSize, df.get("outSocket").get.first().size)
+    Assert.assertEquals(expectedResult, df.get("outSocket").get.first().toString())
+
+  }
+
+  @Test
+  def itShouldReadFieldAsNullForIncorrectDataTypeWhenSafeTrue(): Unit = {
+
+    //Given
+
+    val inputPathCase2: String = "testData/inputFiles/employees2.txt"
+
+    inputFileDelimitedEntity.setStrict(true)
+    inputFileDelimitedEntity.setSafe(true)
+    inputFileDelimitedEntity.setPath(inputPathCase2)
+
+    //when
+
+    val df: Map[String, DataFrame] = new InputFileCsvUnivocityComponent(inputFileDelimitedEntity, cp).createComponent()
+
+    //Then
+
+    val expectedSize: Int = 8
+    val expectedResult: String = "[3,Hemant,68.36,BBSR,OD,2015-06-25,2016-06-25 02:02:02.325,50.300,null]"
+    Assert.assertEquals(expectedSize, df.get("outSocket").get.first().size)
+    Assert.assertEquals(expectedResult, df.get("outSocket").get.first().toString())
+
+  }
+
+  /*Test Cases For Blank Fields Input Starts Here*/
+
+  @Test
+  def itShouldReadNullWhenFieldIsNullAndSafeTrue(): Unit = {
+
+    //Given
+
+    val inputPathCase3: String = "testData/inputFiles/employees3.txt"
+
+    inputFileDelimitedEntity.setStrict(true)
+    inputFileDelimitedEntity.setSafe(true)
+    inputFileDelimitedEntity.setPath(inputPathCase3)
+
+    //when
+
+    val df: Map[String, DataFrame] = new InputFileCsvUnivocityComponent(inputFileDelimitedEntity, cp).createComponent()
+
+    //Then
+
+    val expectedSize: Int = 8
+    val expectedResult: String = "[3,Hemant,null,BBSR,OD,2015-06-25,2016-06-25 02:02:02.325,50.300,null]"
+    Assert.assertEquals(expectedSize, df.get("outSocket").get.first().size)
+    Assert.assertEquals(expectedResult, df.get("outSocket").get.first().toString())
+
+  }
+
+  @Test(expected = classOf[SparkException])
+  def itShouldThrowExceptionWhenFieldIsNullAndSafeFalse(): Unit = {
+
+    //Given
+
+    val inputPathCase3: String = "testData/inputFiles/employees6.txt"
+
+    inputFileDelimitedEntity.setStrict(true)
+    inputFileDelimitedEntity.setSafe(false)
+    inputFileDelimitedEntity.setPath(inputPathCase3)
+
+    //when
+
+    val df: Map[String, DataFrame] = new InputFileCsvUnivocityComponent(inputFileDelimitedEntity, cp).createComponent()
+
+    //Then
+
+    val expectedSize: Int = 8
+    //val expectedResult: String = "[3.5,Hemant,null,BBSR,OD,2015-06-25,2016-06-25 02:02:02.325,50.300,null]"
+    Assert.assertEquals(expectedSize, df.get("outSocket").get.first().size)
+    //Assert.assertEquals(expectedResult, df.get("outSocket").get.first().toString())
+
+  }
+
+  /*Test Cases For Missing Fields Input Starts Here*/
+
+  @Test(expected = classOf[SparkException])
+  def itShouldThrowExceptionWhenFieldMissingAndStrictTrue(): Unit = {
+
+    //Given
+
+    val inputPathCase4: String = "testData/inputFiles/employees4.txt"
+
+    inputFileDelimitedEntity.setStrict(true)
+    inputFileDelimitedEntity.setSafe(true)
+    inputFileDelimitedEntity.setPath(inputPathCase4)
+
+    //when
+
+    val df: Map[String, DataFrame] = new InputFileCsvUnivocityComponent(inputFileDelimitedEntity, cp).createComponent()
+
+    //Then
+
+    val expectedSize: Int = 8
+    val expectedResult: String = "[3,Hemant,null,BBSR,OD,2015-06-25,2016-06-25 02:02:02.325,null,null]"
+    Assert.assertEquals(expectedSize, df.get("outSocket").get.first().size)
+    Assert.assertEquals(expectedResult, df.get("outSocket").get.first().toString())
+
+  }
+
+  @Test
+  def itShouldReadNullForMissingFieldWhenStrictFalseAndSafeTrue(): Unit = {
+
+    //Given
+
+    val inputPathCase4: String = "testData/inputFiles/employees4.txt"
+
+    inputFileDelimitedEntity.setStrict(false)
+    inputFileDelimitedEntity.setSafe(true)
+    inputFileDelimitedEntity.setPath(inputPathCase4)
+
+    //when
+
+    val df: Map[String, DataFrame] = new InputFileCsvUnivocityComponent(inputFileDelimitedEntity, cp).createComponent()
+
+    //Then
+
+    val expectedSize: Int = 8
+    val expectedResult: String = "[3,Hemant,68.36,BBSR,OD,2015-06-25,2016-06-25 02:02:02.325,null,null]"
+    Assert.assertEquals(expectedSize, df.get("outSocket").get.first().size)
+    Assert.assertEquals(expectedResult, df.get("outSocket").get.first().toString())
+
+  }
+
+  @Test(expected = classOf[SparkException])
+  def itShouldThrowExceptionForMissingFieldWhenStrictFalseAndSafeFalse(): Unit = {
+
+    //Given
+
+    val inputPathCase4: String = "testData/inputFiles/employees7.txt"
+
+    inputFileDelimitedEntity.setStrict(false)
+    inputFileDelimitedEntity.setSafe(false)
+    inputFileDelimitedEntity.setPath(inputPathCase4)
+
+    //when
+
+    val df: Map[String, DataFrame] = new InputFileCsvUnivocityComponent(inputFileDelimitedEntity, cp).createComponent()
+
+    //Then
+
+    val expectedSize: Int = 8
+    //val expectedResult: String = "[null,Hemant,68.36,BBSR,OD,2015-06-25,2016-06-25 02:02:02.325,null,null]"
+    Assert.assertEquals(expectedSize, df.get("outSocket").get.first().size)
+    //Assert.assertEquals(expectedResult, df.get("outSocket").get.first().toString())
+
+  }
+
+}

--- a/hydrograph.engine/hydrograph.engine.spark/src/test/scala/hydrograph/engine/spark/components/InputFileCsvUnivocityComponentTest.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/test/scala/hydrograph/engine/spark/components/InputFileCsvUnivocityComponentTest.scala
@@ -84,7 +84,7 @@ class InputFileCsvUnivocityComponentTest {
 
     //Given
 
-    val inputPathCase0: String = "testData/inputFiles/employees.txt"
+    val inputPathCase0: String = "./../hydrograph.engine.command-line/testData/Input/employees.txt"
 
     inputFileDelimitedEntity.setStrict(true)
     inputFileDelimitedEntity.setSafe(false)
@@ -107,7 +107,7 @@ class InputFileCsvUnivocityComponentTest {
 
     //Given
 
-    val inputPathCase1: String = "testData/inputFiles/employees1.txt"
+    val inputPathCase1: String = "./../hydrograph.engine.command-line/testData/Input/employees1.txt"
 
     inputFileDelimitedEntity.setStrict(true)
     inputFileDelimitedEntity.setSafe(false)
@@ -131,7 +131,7 @@ class InputFileCsvUnivocityComponentTest {
 
     //Given
 
-    val inputPathCase2: String = "testData/inputFiles/employees2.txt"
+    val inputPathCase2: String = "./../hydrograph.engine.command-line/testData/Input/employees2.txt"
 
     inputFileDelimitedEntity.setStrict(true)
     inputFileDelimitedEntity.setSafe(true)
@@ -157,7 +157,7 @@ class InputFileCsvUnivocityComponentTest {
 
     //Given
 
-    val inputPathCase3: String = "testData/inputFiles/employees3.txt"
+    val inputPathCase3: String = "./../hydrograph.engine.command-line/testData/Input/employees3.txt"
 
     inputFileDelimitedEntity.setStrict(true)
     inputFileDelimitedEntity.setSafe(true)
@@ -181,7 +181,7 @@ class InputFileCsvUnivocityComponentTest {
 
     //Given
 
-    val inputPathCase3: String = "testData/inputFiles/employees6.txt"
+    val inputPathCase3: String = "./../hydrograph.engine.command-line/testData/Input/employees6.txt"
 
     inputFileDelimitedEntity.setStrict(true)
     inputFileDelimitedEntity.setSafe(false)
@@ -207,7 +207,7 @@ class InputFileCsvUnivocityComponentTest {
 
     //Given
 
-    val inputPathCase4: String = "testData/inputFiles/employees4.txt"
+    val inputPathCase4: String = "./../hydrograph.engine.command-line/testData/Input/employees4.txt"
 
     inputFileDelimitedEntity.setStrict(true)
     inputFileDelimitedEntity.setSafe(true)
@@ -231,7 +231,7 @@ class InputFileCsvUnivocityComponentTest {
 
     //Given
 
-    val inputPathCase4: String = "testData/inputFiles/employees4.txt"
+    val inputPathCase4: String = "./../hydrograph.engine.command-line/testData/Input/employees4.txt"
 
     inputFileDelimitedEntity.setStrict(false)
     inputFileDelimitedEntity.setSafe(true)
@@ -255,7 +255,7 @@ class InputFileCsvUnivocityComponentTest {
 
     //Given
 
-    val inputPathCase4: String = "testData/inputFiles/employees7.txt"
+    val inputPathCase4: String = "./../hydrograph.engine.command-line/testData/Input/employees7.txt"
 
     inputFileDelimitedEntity.setStrict(false)
     inputFileDelimitedEntity.setSafe(false)

--- a/hydrograph.engine/hydrograph.engine.spark/src/test/scala/hydrograph/engine/spark/components/OutputFileCsvUnivocityComponentTest.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/test/scala/hydrograph/engine/spark/components/OutputFileCsvUnivocityComponentTest.scala
@@ -40,7 +40,7 @@ class OutputFileCsvUnivocityComponentTest {
       .build()
 
 
-    outputFileDelimitedEntity.setPath("testData/outputFiles/delimitedOutput")
+    outputFileDelimitedEntity.setPath("testData/outputFiles/csvUnivocityOutput")
     val sf0: SchemaField = new SchemaField("col1", "java.lang.String")
     val sf1: SchemaField = new SchemaField("col2", "java.lang.Double")
     val sf2: SchemaField = new SchemaField("col3", "java.lang.Float")
@@ -85,7 +85,7 @@ class OutputFileCsvUnivocityComponentTest {
     val comp = new OutputFileCsvUnivocityComponent(outputFileDelimitedEntity, baseComponentParams)
     comp.execute()
 
-    val dataFrame = spark.read.format("text").load("testData/outputFiles/delimitedOutput")
+    val dataFrame = spark.read.format("text").load("testData/outputFiles/csvUnivocityOutput")
 
     //then
     val expectedHeader = "[col1,col2,col3,col4,col5,col6,col7,col8,col9,col10]"
@@ -103,7 +103,7 @@ class OutputFileCsvUnivocityComponentTest {
     val comp = new OutputFileCsvUnivocityComponent(outputFileDelimitedEntity, baseComponentParams)
     comp.execute()
 
-    val dataFrame = spark.read.format("text").load("testData/outputFiles/delimitedOutput")
+    val dataFrame = spark.read.format("text").load("testData/outputFiles/csvUnivocityOutput")
 
     //then
     val expectedRowData = "[aaa,1.25,0.25,25,35,147258,true,12.1500000000,2014-02-05,2014-02-05 14:25:36]"
@@ -124,7 +124,7 @@ class OutputFileCsvUnivocityComponentTest {
     val comp = new OutputFileCsvUnivocityComponent(outputFileDelimitedEntity, baseComponentParams)
     comp.execute()
 
-    val dataFrame = spark.read.format("text").load("testData/outputFiles/delimitedOutput")
+    val dataFrame = spark.read.format("text").load("testData/outputFiles/csvUnivocityOutput")
 
     //then
     val expectedRowData = "[aaa|1.25|0.25|25|35|147258|true|12.1500000000|2014-02-05|2014-02-05 14:25:36]"
@@ -145,7 +145,7 @@ class OutputFileCsvUnivocityComponentTest {
       .build()
 
     val outputFileDelimitedEntity1: OutputFileDelimitedEntity = new OutputFileDelimitedEntity
-    outputFileDelimitedEntity1.setPath("testData/outputFiles/delimitedFewColumnOutput")
+    outputFileDelimitedEntity1.setPath("testData/outputFiles/csvUnivocityFewColumnOutput")
     val sf0: SchemaField = new SchemaField("col1", "java.lang.String")
     val sf1: SchemaField = new SchemaField("col2", "java.lang.Double")
     val sf2: SchemaField = new SchemaField("col3", "java.lang.Float")
@@ -166,7 +166,7 @@ class OutputFileCsvUnivocityComponentTest {
     val comp = new OutputFileCsvUnivocityComponent(outputFileDelimitedEntity1, baseComponentParams)
     comp.execute()
 
-    val dataFrame = spark.read.format("text").load("testData/outputFiles/delimitedFewColumnOutput")
+    val dataFrame = spark.read.format("text").load("testData/outputFiles/csvUnivocityFewColumnOutput")
 
     //then
     val expectedRowData = "[aaa,1.25,0.25]"
@@ -186,7 +186,7 @@ class OutputFileCsvUnivocityComponentTest {
       .build()
 
     val outputFileDelimitedEntity2: OutputFileDelimitedEntity = new OutputFileDelimitedEntity
-    outputFileDelimitedEntity2.setPath("testData/outputFiles/delimitedOutputQuote")
+    outputFileDelimitedEntity2.setPath("testData/outputFiles/csvUnivocityOutputQuote")
     val sf0: SchemaField = new SchemaField("col1", "java.lang.Integer")
     val sf1: SchemaField = new SchemaField("col2", "java.lang.String")
     val sf2: SchemaField = new SchemaField("col3", "java.lang.Float")
@@ -207,7 +207,7 @@ class OutputFileCsvUnivocityComponentTest {
     val comp = new OutputFileCsvUnivocityComponent(outputFileDelimitedEntity2, baseComponentParams1)
     comp.execute()
 
-    val dataFrame = spark.read.format("text").load("testData/outputFiles/delimitedOutputQuote")
+    val dataFrame = spark.read.format("text").load("testData/outputFiles/csvUnivocityOutputQuote")
 
     //then
     val expectedRowData = "[1,'aaa,bbb',1.25]"

--- a/hydrograph.engine/hydrograph.engine.spark/src/test/scala/hydrograph/engine/spark/components/OutputFileCsvUnivocityComponentTest.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/test/scala/hydrograph/engine/spark/components/OutputFileCsvUnivocityComponentTest.scala
@@ -1,0 +1,218 @@
+package hydrograph.engine.spark.components
+
+import java.sql.Timestamp
+import java.util.Date
+
+import hydrograph.engine.core.component.entity.OutputFileDelimitedEntity
+import hydrograph.engine.core.component.entity.elements.SchemaField
+import hydrograph.engine.spark.components.platform.BaseComponentParams
+import hydrograph.engine.spark.components.utils.SchemaCreator
+import hydrograph.engine.testing.wrapper.{DataBuilder, Fields}
+import org.apache.spark.sql.SparkSession
+import org.junit.{Assert, Before, Test}
+
+import scala.collection.JavaConverters._
+
+/**
+  * The Class OutputFileCsvUnivocityComponentTest.
+  *
+  * @author Bitwise
+  *
+  */
+class OutputFileCsvUnivocityComponentTest {
+
+  val outputFileDelimitedEntity: OutputFileDelimitedEntity = new OutputFileDelimitedEntity
+  val baseComponentParams = new BaseComponentParams
+  val spark:SparkSession  = SparkSession.builder()
+    .master("local")
+    .appName("testing")
+    .config("spark.sql.shuffle.partitions", "1")
+    .config("spark.sql.warehouse.dir", "file:///tmp")
+    .getOrCreate()
+
+  @Before
+  def executedBeforeEachTestCase(): Unit = {
+
+    val df = new DataBuilder(Fields(List("col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10"))
+      .applyTypes(List(classOf[String], classOf[Double], classOf[Float], classOf[Short], classOf[Integer], classOf[Long],
+        classOf[Boolean], classOf[BigDecimal], classOf[Date], classOf[Timestamp])))
+      .addData(List("aaa", 1.25, 0.25, 25, 35, 147258, true, 12.15, "2014-02-05", "2014-02-05 14:25:36"))
+      .build()
+
+
+    outputFileDelimitedEntity.setPath("testData/outputFiles/delimitedOutput")
+    val sf0: SchemaField = new SchemaField("col1", "java.lang.String")
+    val sf1: SchemaField = new SchemaField("col2", "java.lang.Double")
+    val sf2: SchemaField = new SchemaField("col3", "java.lang.Float")
+    val sf3: SchemaField = new SchemaField("col4", "java.lang.Short")
+    val sf4: SchemaField = new SchemaField("col5", "java.lang.Integer")
+    val sf5: SchemaField = new SchemaField("col6", "java.lang.Long")
+    val sf6: SchemaField = new SchemaField("col7", "java.lang.Boolean")
+    val sf7: SchemaField = new SchemaField("col8", "java.math.BigDecimal");
+    sf7.setFieldPrecision(5)
+    sf7.setFieldScale(2)
+    val sf8: SchemaField = new SchemaField("col9", "java.util.Date");
+    sf8.setFieldFormat("yyyy-MM-dd")
+    val sf9: SchemaField = new SchemaField("col10", "java.util.Date");
+    sf9.setFieldFormat("yyyy-MM-dd HH:mm:ss")
+
+
+    val list: List[SchemaField] = List(sf0, sf1, sf2, sf3, sf4, sf5, sf6, sf7, sf8, sf9)
+    val javaList = list.asJava
+    outputFileDelimitedEntity.setFieldsList(javaList)
+    outputFileDelimitedEntity.setComponentName("Output delimited File")
+    outputFileDelimitedEntity.setComponentId("OutputDelimited")
+    outputFileDelimitedEntity.setDelimiter(",")
+    outputFileDelimitedEntity.setOverWrite(true)
+    outputFileDelimitedEntity.setCharset("UTF-8")
+
+
+    baseComponentParams.addinputDataFrame(df)
+
+    val schemaField = SchemaCreator(outputFileDelimitedEntity).makeSchema()
+  }
+
+  /**
+    * Test of Header
+    */
+  @Test
+  def itShouldCheckFirstRecordInOutputFileIsHeaderWhenHasHeaderIsTrue() : Unit = {
+
+    //given
+    outputFileDelimitedEntity.setHasHeader(true)
+
+    //when
+    val comp = new OutputFileCsvUnivocityComponent(outputFileDelimitedEntity, baseComponentParams)
+    comp.execute()
+
+    val dataFrame = spark.read.format("text").load("testData/outputFiles/delimitedOutput")
+
+    //then
+    val expectedHeader = "[col1,col2,col3,col4,col5,col6,col7,col8,col9,col10]"
+
+    Assert.assertEquals(expectedHeader,dataFrame.collectAsList().get(0).toString())
+  }
+
+  @Test
+  def itShouldCheckFirstRecordInOutputFileIsDataWhenHasHeaderIsFalse() : Unit = {
+
+    //given
+    outputFileDelimitedEntity.setHasHeader(false)
+
+    //when
+    val comp = new OutputFileCsvUnivocityComponent(outputFileDelimitedEntity, baseComponentParams)
+    comp.execute()
+
+    val dataFrame = spark.read.format("text").load("testData/outputFiles/delimitedOutput")
+
+    //then
+    val expectedRowData = "[aaa,1.25,0.25,25,35,147258,true,12.1500000000,2014-02-05,2014-02-05 14:25:36]"
+
+    Assert.assertEquals(expectedRowData,dataFrame.collectAsList().get(0).toString())
+  }
+
+  /**
+    * Test of delimiter
+    */
+  @Test
+  def itShouldWriteFileWithProvidedDelimiter() : Unit = {
+
+    //given
+    outputFileDelimitedEntity.setDelimiter("|")
+
+    //when
+    val comp = new OutputFileCsvUnivocityComponent(outputFileDelimitedEntity, baseComponentParams)
+    comp.execute()
+
+    val dataFrame = spark.read.format("text").load("testData/outputFiles/delimitedOutput")
+
+    //then
+    val expectedRowData = "[aaa|1.25|0.25|25|35|147258|true|12.1500000000|2014-02-05|2014-02-05 14:25:36]"
+
+    Assert.assertEquals(expectedRowData,dataFrame.collectAsList().get(0).toString())
+  }
+
+  /**
+    * Test of selective Write
+    */
+  @Test
+  def itShouldWriteFewColumnProvidedInEntity() : Unit = {
+
+    val df = new DataBuilder(Fields(List("col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10"))
+      .applyTypes(List(classOf[String], classOf[Double], classOf[Float], classOf[Short], classOf[Integer], classOf[Long],
+        classOf[Boolean], classOf[BigDecimal], classOf[Date], classOf[Timestamp])))
+      .addData(List("aaa", 1.25, 0.25, 25, 35, 147258, true, 12.15, "2014-02-05", "2014-02-05 14:25:36"))
+      .build()
+
+    val outputFileDelimitedEntity1: OutputFileDelimitedEntity = new OutputFileDelimitedEntity
+    outputFileDelimitedEntity1.setPath("testData/outputFiles/delimitedFewColumnOutput")
+    val sf0: SchemaField = new SchemaField("col1", "java.lang.String")
+    val sf1: SchemaField = new SchemaField("col2", "java.lang.Double")
+    val sf2: SchemaField = new SchemaField("col3", "java.lang.Float")
+
+    val list: List[SchemaField] = List(sf0, sf1, sf2)
+    outputFileDelimitedEntity1.setFieldsList(list.asJava)
+    outputFileDelimitedEntity1.setComponentName("Output delimited File")
+    outputFileDelimitedEntity1.setComponentId("OutputDelimited")
+    outputFileDelimitedEntity1.setDelimiter(",")
+    outputFileDelimitedEntity1.setOverWrite(true)
+    outputFileDelimitedEntity1.setCharset("UTF-8")
+
+    baseComponentParams.addinputDataFrame(df)
+
+    val schemaField = SchemaCreator(outputFileDelimitedEntity1).makeSchema()
+
+    //when
+    val comp = new OutputFileCsvUnivocityComponent(outputFileDelimitedEntity1, baseComponentParams)
+    comp.execute()
+
+    val dataFrame = spark.read.format("text").load("testData/outputFiles/delimitedFewColumnOutput")
+
+    //then
+    val expectedRowData = "[aaa,1.25,0.25]"
+
+    Assert.assertEquals(expectedRowData,dataFrame.collectAsList().get(0).toString())
+  }
+
+  /**
+    * Test of Quote
+    */
+  @Test
+  def itShouldWriteQuoteCharacterInOutputFile() : Unit = {
+
+    val df1 = new DataBuilder(Fields(List("col1", "col2", "col3"))
+      .applyTypes(List(classOf[Integer], classOf[String], classOf[Float])))
+      .addData(List(1,"aaa,bbb", 1.25))
+      .build()
+
+    val outputFileDelimitedEntity2: OutputFileDelimitedEntity = new OutputFileDelimitedEntity
+    outputFileDelimitedEntity2.setPath("testData/outputFiles/delimitedOutputQuote")
+    val sf0: SchemaField = new SchemaField("col1", "java.lang.Integer")
+    val sf1: SchemaField = new SchemaField("col2", "java.lang.String")
+    val sf2: SchemaField = new SchemaField("col3", "java.lang.Float")
+
+    val list: List[SchemaField] = List(sf0, sf1, sf2)
+    outputFileDelimitedEntity2.setFieldsList(list.asJava)
+    outputFileDelimitedEntity2.setComponentName("Output delimited File")
+    outputFileDelimitedEntity2.setComponentId("OutputDelimited")
+    outputFileDelimitedEntity2.setDelimiter(",")
+    outputFileDelimitedEntity2.setOverWrite(true)
+    outputFileDelimitedEntity2.setQuote("\'")
+    outputFileDelimitedEntity2.setCharset("UTF-8")
+
+    val baseComponentParams1 = new BaseComponentParams
+    baseComponentParams1.addinputDataFrame(df1)
+
+    //when
+    val comp = new OutputFileCsvUnivocityComponent(outputFileDelimitedEntity2, baseComponentParams1)
+    comp.execute()
+
+    val dataFrame = spark.read.format("text").load("testData/outputFiles/delimitedOutputQuote")
+
+    //then
+    val expectedRowData = "[1,'aaa,bbb',1.25]"
+
+    Assert.assertEquals(expectedRowData,dataFrame.collectAsList().get(0).toString())
+  }
+
+}


### PR DESCRIPTION
Implemented Strict and Safe property in text delimited component input component which uses Univocity parser.
Strict property asserts number of fields in input file and the input schema. If it's value is true then job fails for mismatch in number of fields and if false null is assigned to extra fields specified in the schema. Default value is true.
Safe property asserts datatype conversion. Data type specified in schema is applied to each String value as file is read in String. When type coercion throws error then if safe property is false job fails and if true null value is assigned to the field. Default value is false.
Added test cases for InputFileCsvUnivocityComponent and OutputFileCsvUnivocityComponent.