### PR TITLE
Changed Redshift dependency from compileOnly to compile in hydrograph.server.debug/build.gradle

### DIFF
--- a/hydrograph.server/hydrograph.server.debug/build.gradle
+++ b/hydrograph.server/hydrograph.server.debug/build.gradle
@@ -103,7 +103,7 @@ dependencies {
 
     //Following are the URL�s to download the jars for RedShift:
     //Redshift: https://s3.amazonaws.com/redshift-downloads/drivers/RedshiftJDBC42-1.2.1.1001.jar
-    compileOnly group: 'com.amazon.redshift', name: 'redshift-jdbc42', version: '1.2.1.1001'
+    compile group: 'com.amazon.redshift', name: 'redshift-jdbc42', version: '1.2.1.1001'
 
     //Following are the URL�s to download the jars for Teradata:
     //Teradata: http://downloads.teradata.com/download/connectivity/jdbc-driver


### PR DESCRIPTION
Issue :
In hydrograph.server.debug/build.gradle,  redshift dependency is compileOnly. If someone tries to download all the relevant jars with help of this build.gradle file, due to compileOnly redshift dependency will not be downloaded(as we have defined copyRuntimeLibs for this purpose).

Solution :
So in order to take care of this problem, we are changing it to compile.