### PR TITLE
Teradata exception handling and minor bug fixes

### DIFF
--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/entity/InputRDBMSEntity.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/entity/InputRDBMSEntity.java
@@ -47,10 +47,10 @@ public class InputRDBMSEntity extends InputOutputEntityBase {
     private String _interface;
     private String temps3dir;
 
-    private Integer numPartitionsValue;
-    private Integer upperBound;
-    private Integer lowerBound;
-    private String columnName;
+    private int numPartitionsValue=Integer.MIN_VALUE;
+    private int upperBound=0;
+    private int lowerBound=0;
+    private String columnName="";
     private String fetchSize;
     private String extraUrlParameters;
 

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/resources/componentMapping.properties
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/resources/componentMapping.properties
@@ -10,8 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 ###############################################################################
-hydrograph.engine.jaxb.inputtypes.TextFileDelimited=hydrograph.engine.spark.components.adapter.InputFileCsvWithDateFormatsAdapter
-hydrograph.engine.jaxb.outputtypes.TextFileDelimited=hydrograph.engine.spark.components.adapter.OutputFileCsvWithDateFormatsAdapter
+hydrograph.engine.jaxb.inputtypes.TextFileDelimited=hydrograph.engine.spark.components.adapter.InputFileCsvUnivocityAdapter
+hydrograph.engine.jaxb.outputtypes.TextFileDelimited=hydrograph.engine.spark.components.adapter.OutputFileCsvUnivocityAdapter
 hydrograph.engine.jaxb.operationstypes.Transform=hydrograph.engine.spark.components.adapter.TransformAdapter
 hydrograph.engine.jaxb.operationstypes.Aggregate=hydrograph.engine.spark.components.adapter.AggregateAdapter
 hydrograph.engine.jaxb.operationstypes.Groupcombine=hydrograph.engine.spark.components.adapter.GroupCombineAdapter

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputTeradataComponent.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputTeradataComponent.scala
@@ -41,10 +41,7 @@ class InputTeradataComponent(inputRDBMSEntity: InputRDBMSEntity,
     val schemaField = SchemaCreator(inputRDBMSEntity).makeSchema()
 
     val sparkSession = iComponentsParams.getSparkSession()
-    val numPartitions: Int = inputRDBMSEntity getNumPartitionsValue match {
-      case null => Int.MinValue
-      case p => inputRDBMSEntity getNumPartitionsValue
-    }
+    val numPartitions: Int = inputRDBMSEntity getNumPartitionsValue
     val upperBound: Int = inputRDBMSEntity getUpperBound
     val lowerBound: Int = inputRDBMSEntity getLowerBound
 

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputTeradataComponent.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/InputTeradataComponent.scala
@@ -13,6 +13,8 @@
 
 package hydrograph.engine.spark.components
 
+import java.sql.SQLException
+
 import hydrograph.engine.core.component.entity.InputRDBMSEntity
 import hydrograph.engine.spark.components.base.InputComponentBase
 import hydrograph.engine.spark.components.platform.BaseComponentParams
@@ -39,7 +41,10 @@ class InputTeradataComponent(inputRDBMSEntity: InputRDBMSEntity,
     val schemaField = SchemaCreator(inputRDBMSEntity).makeSchema()
 
     val sparkSession = iComponentsParams.getSparkSession()
-    val numPartitions: Int = inputRDBMSEntity getNumPartitionsValue
+    val numPartitions: Int = inputRDBMSEntity getNumPartitionsValue match {
+      case null => Int.MinValue
+      case p => inputRDBMSEntity getNumPartitionsValue
+    }
     val upperBound: Int = inputRDBMSEntity getUpperBound
     val lowerBound: Int = inputRDBMSEntity getLowerBound
 
@@ -110,6 +115,9 @@ class InputTeradataComponent(inputRDBMSEntity: InputRDBMSEntity,
       val key = inputRDBMSEntity.getOutSocketList.get(0).getSocketId
       Map(key -> df)
     } catch {
+      case e: SQLException =>
+        LOG.error("\"Error in Input  Teradata input component '" + inputRDBMSEntity.getComponentId + "', Error" + e.getMessage, e)
+        throw TableDoesNotExistException("\"Error in Input  Teradata input component '" + inputRDBMSEntity.getComponentId + "', Error" + e.getMessage, e)
       case e: Exception =>
         LOG.error("Error in Input  Teradata input component '" + inputRDBMSEntity.getComponentId + "', Error" + e.getMessage, e)
         throw new RuntimeException("Error in Input Teradata Component " + inputRDBMSEntity.getComponentId, e)
@@ -120,8 +128,9 @@ class InputTeradataComponent(inputRDBMSEntity: InputRDBMSEntity,
 
   private def getDataType(dataType: DataType): Option[DataType] = {
     dataType.typeName.toUpperCase match {
-      case "DOUBLE" => Option(FloatType)  /** In teradata if we create a table with a field type as Double,
-        *it creates a schema and replaces the Double datatype with Float datatype which is Teradata specific.
+      case "DOUBLE" => Option(FloatType)
+      /** In teradata if we create a table with a field type as Double,
+        * it creates a schema and replaces the Double datatype with Float datatype which is Teradata specific.
         * Contrary to that if we attempt to read the data from a Teradata table, we have created by using the
         * output schema as Double, the execution gets stopped
         * as the data gets exported from Teradata as Float. In order to get Double type data while reading from a Teradata
@@ -132,3 +141,4 @@ class InputTeradataComponent(inputRDBMSEntity: InputRDBMSEntity,
     }
   }
 }
+case class TableDoesNotExistException(errorMessage: String, e: Exception) extends RuntimeException(errorMessage,e)


### PR DESCRIPTION
Handled Runtime exception in teradata component and Null values appearing in the test cases of the db components when the numPartitions parameter and the other dependent parameters were not initialized. initialized the partition values, upper bound and lower bound with default values such that the execution does not break when the above mentioned values are not initialized by the end user.

Update: The Csv adapter has been changed to a univocity parser enabled adapter