### PR TITLE
Bugfix846:  String value in Additional DB Parameters has been trimmed

### DIFF
--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputMysqlEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputMysqlEntityGenerator.java
@@ -131,7 +131,7 @@ public class InputMysqlEntityGenerator extends
         //inputRDBMSEntity.setExtraUrlParameters(inputMysqlJaxb.getExtraUrlParams()==null?null:inputMysqlJaxb.getExtraUrlParams().getValue());
         if(inputMysqlJaxb.getExtraUrlParams()!=null){
             if(inputMysqlJaxb.getExtraUrlParams().getValue().contains(",")){
-                String correctedParams = inputMysqlJaxb.getExtraUrlParams().getValue().replace(",","&");
+                String correctedParams = inputMysqlJaxb.getExtraUrlParams().getValue().replaceAll("\\s+","").replace(",","&");
 
                 LOG.info("using extra url params as" + correctedParams);
                 inputRDBMSEntity.setExtraUrlParameters(correctedParams);

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputOracleEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputOracleEntityGenerator.java
@@ -138,7 +138,17 @@ InputComponentGeneratorBase {
         //fetchsize
         inputRDBMSEntity.setFetchSize(inputOracleJaxb.getFetchSize()==null?null: inputOracleJaxb.getFetchSize().getValue());
         //extra url parameters
-        inputRDBMSEntity.setExtraUrlParameters(inputOracleJaxb.getExtraUrlParams()==null?null:inputOracleJaxb.getExtraUrlParams().getValue());
+
+        if(inputOracleJaxb.getExtraUrlParams()!=null){
+            if(inputOracleJaxb.getExtraUrlParams().getValue().contains(",")){
+                String correctedParams = inputOracleJaxb.getExtraUrlParams().getValue().replaceAll("\\s+","").replace(",","&");
+
+                LOG.info("using extra url params as" + correctedParams);
+                inputRDBMSEntity.setExtraUrlParameters(correctedParams);
+            }
+        }else if(inputOracleJaxb.getExtraUrlParams()==null){
+            inputRDBMSEntity.setExtraUrlParameters(null);
+        }
 
         /**END*/
     }

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputTeradataEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputTeradataEntityGenerator.java
@@ -126,7 +126,17 @@ public class InputTeradataEntityGenerator extends
         //fetchsize
         inputRDBMSEntity.setFetchSize(inputTeradataJaxb.getFetchSize()==null?null: inputTeradataJaxb.getFetchSize().getValue());
         //extra url parameters
-        inputRDBMSEntity.setExtraUrlParameters(inputTeradataJaxb.getExtraUrlParams()==null?null:inputTeradataJaxb.getExtraUrlParams().getValue());
+        if(inputTeradataJaxb.getExtraUrlParams()!=null){
+            if(inputTeradataJaxb.getExtraUrlParams().getValue().contains(",")){
+                String correctedParams = inputTeradataJaxb.getExtraUrlParams().getValue().replaceAll("\\s+","");
+
+                LOG.info("using extra url params as" + correctedParams);
+                inputRDBMSEntity.setExtraUrlParameters(correctedParams);
+            }
+        }else if(inputTeradataJaxb.getExtraUrlParams()==null){
+            inputRDBMSEntity.setExtraUrlParameters(null);
+        }
+
 
         /**END*/
         inputRDBMSEntity.setDatabaseType("Teradata");


### PR DESCRIPTION
Made changes to the entity generators of the Database components( MySQL, Oracle and Teradata) such that the parameter entered by user gets trimmed should the same contain a white space.