### PR TITLE
Bugfix validating extra url parameters in Database components 

### DIFF
--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputMysqlEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputMysqlEntityGenerator.java
@@ -131,7 +131,7 @@ public class InputMysqlEntityGenerator extends
         //inputRDBMSEntity.setExtraUrlParameters(inputMysqlJaxb.getExtraUrlParams()==null?null:inputMysqlJaxb.getExtraUrlParams().getValue());
         if(inputMysqlJaxb.getExtraUrlParams()!=null){
             if(inputMysqlJaxb.getExtraUrlParams().getValue().contains(",")){
-                String correctedParams = inputMysqlJaxb.getExtraUrlParams().getValue().replace(",","&");
+                String correctedParams = inputMysqlJaxb.getExtraUrlParams().getValue().replaceAll("\\s+","").replace(",","&");
 
                 LOG.info("using extra url params as" + correctedParams);
                 inputRDBMSEntity.setExtraUrlParameters(correctedParams);

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputMysqlEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputMysqlEntityGenerator.java
@@ -22,12 +22,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * The Class InputMysqlEntityGenerator.
  *
  * @author Bitwise
- *
  */
 public class InputMysqlEntityGenerator extends
         InputComponentGeneratorBase {
@@ -69,19 +70,19 @@ public class InputMysqlEntityGenerator extends
         if (inputMysqlJaxb.getPort() == null)
             LOG.warn("Input Mysql component '" + inputRDBMSEntity.getComponentId() + "' port is not provided, using default port " + Constants.DEFAULT_MYSQL_PORT);
         inputRDBMSEntity.setPort(inputMysqlJaxb.getPort() == null ? Constants.DEFAULT_MYSQL_PORT : inputMysqlJaxb.getPort().getValue().intValue());
-        inputRDBMSEntity.setJdbcDriver(inputMysqlJaxb.getJdbcDriver()==null ?null: inputMysqlJaxb.getJdbcDriver().getValue());
+        inputRDBMSEntity.setJdbcDriver(inputMysqlJaxb.getJdbcDriver() == null ? null : inputMysqlJaxb.getJdbcDriver().getValue());
         inputRDBMSEntity.setTableName(inputMysqlJaxb.getTableName() == null ? null : inputMysqlJaxb.getTableName().getValue());
         inputRDBMSEntity.setSelectQuery(inputMysqlJaxb.getSelectQuery() == null ? null : inputMysqlJaxb.getSelectQuery().getValue());
-        inputRDBMSEntity.setCountQuery(inputMysqlJaxb.getCountQuery()==null?("select count(*) from  (" +inputRDBMSEntity.getSelectQuery()+ ") as alias;"):inputMysqlJaxb.getCountQuery().getValue());
+        inputRDBMSEntity.setCountQuery(inputMysqlJaxb.getCountQuery() == null ? ("select count(*) from  (" + inputRDBMSEntity.getSelectQuery() + ") as alias;") : inputMysqlJaxb.getCountQuery().getValue());
         inputRDBMSEntity.setUsername(inputMysqlJaxb.getUsername().getValue());
         inputRDBMSEntity.setPassword(inputMysqlJaxb.getPassword().getValue());
 //		inputRDBMSEntity.setFetchSize(inputMysqlJaxb.getFetchSize()==null?Constants.DEFAULT_DB_FETCHSIZE:inputMysqlJaxb.getFetchSize().getValue().intValue());
-        inputRDBMSEntity.setRuntimeProperties(inputMysqlJaxb.getRuntimeProperties() == null ? new Properties():InputEntityUtils
-                        .extractRuntimeProperties(inputMysqlJaxb.getRuntimeProperties()));
+        inputRDBMSEntity.setRuntimeProperties(inputMysqlJaxb.getRuntimeProperties() == null ? new Properties() : InputEntityUtils
+                .extractRuntimeProperties(inputMysqlJaxb.getRuntimeProperties()));
 
         /**new parameters that has been added after the open source release*/
-        inputRDBMSEntity.setNumPartitionsValue(inputMysqlJaxb.getNumPartitions() == null? Integer.MIN_VALUE:inputMysqlJaxb.getNumPartitions().getValue().intValue());
-        if(inputMysqlJaxb.getNumPartitions()!=null&&inputMysqlJaxb.getNumPartitions().getValue().intValue()==0){
+        inputRDBMSEntity.setNumPartitionsValue(inputMysqlJaxb.getNumPartitions() == null ? Integer.MIN_VALUE : inputMysqlJaxb.getNumPartitions().getValue().intValue());
+        if (inputMysqlJaxb.getNumPartitions() != null && inputMysqlJaxb.getNumPartitions().getValue().intValue() == 0) {
             LOG.warn("The number of partitions has been entered as ZERO," +
                     "\nThe Execution shall still continue but will work on a single" +
                     "\npartition hence impacting performance");
@@ -94,49 +95,76 @@ public class InputMysqlEntityGenerator extends
          *          the values from the below parameters listed and the second one which does partitoning accepts the
          *          aforementioned parameters. Absence of any one parameter may lead to undesirable outcomes
          * */
-        if(inputMysqlJaxb.getNumPartitions()==null){
+        if (inputMysqlJaxb.getNumPartitions() == null) {
             inputRDBMSEntity.setUpperBound(0);
             inputRDBMSEntity.setLowerBound(0);
             inputRDBMSEntity.setColumnName("");
-        }
-        else {
+        } else {
             if (inputMysqlJaxb.getNumPartitions().getUpperBound() == null) {
-                throw new RuntimeException("Error in Input Mysql Component '"+inputMysqlJaxb.getId()+"' Upper bound cannot be NULL when numPartitions holds an integer value");
-            } else inputRDBMSEntity.setUpperBound(inputMysqlJaxb.getNumPartitions().getUpperBound().getValue().intValue());
+                throw new RuntimeException("Error in Input Mysql Component '" + inputMysqlJaxb.getId() + "' Upper bound cannot be NULL when numPartitions holds an integer value");
+            } else
+                inputRDBMSEntity.setUpperBound(inputMysqlJaxb.getNumPartitions().getUpperBound().getValue().intValue());
 
             if (inputMysqlJaxb.getNumPartitions().getLowerBound() == null) {
-                throw new RuntimeException("Error in Input Mysql Component '"+inputMysqlJaxb.getId()+"' Lower bound cannot be NULL when numPartitions holds an integer value");
-            } else inputRDBMSEntity.setLowerBound(inputMysqlJaxb.getNumPartitions().getLowerBound().getValue().intValue());
+                throw new RuntimeException("Error in Input Mysql Component '" + inputMysqlJaxb.getId() + "' Lower bound cannot be NULL when numPartitions holds an integer value");
+            } else
+                inputRDBMSEntity.setLowerBound(inputMysqlJaxb.getNumPartitions().getLowerBound().getValue().intValue());
 
             if (inputMysqlJaxb.getNumPartitions().getColumnName() == null) {
-                throw new RuntimeException("Error in Input Oracle Component '"+inputMysqlJaxb.getId()+"' Column Name cannot be NULL when numPartitions holds an integer value");
+                throw new RuntimeException("Error in Input Oracle Component '" + inputMysqlJaxb.getId() + "' Column Name cannot be NULL when numPartitions holds an integer value");
             } else inputRDBMSEntity.setColumnName(inputMysqlJaxb.getNumPartitions().getColumnName().getValue());
 
-            if(inputMysqlJaxb.getNumPartitions().getLowerBound().getValue()
-                    .intValue()==inputMysqlJaxb.getNumPartitions().getUpperBound().getValue().intValue()){
-                LOG.warn("'"+inputMysqlJaxb.getId()+"'The upper bound and the lower bound values are same! In this case there will only be\n" +
+            if (inputMysqlJaxb.getNumPartitions().getLowerBound().getValue()
+                    .intValue() == inputMysqlJaxb.getNumPartitions().getUpperBound().getValue().intValue()) {
+                LOG.warn("'" + inputMysqlJaxb.getId() + "'The upper bound and the lower bound values are same! In this case there will only be\n" +
                         "a single partition");
             }
-            if(inputMysqlJaxb.getNumPartitions().getLowerBound().getValue()
-                    .intValue()>inputMysqlJaxb.getNumPartitions().getUpperBound().getValue().intValue()){
-                LOG.error("Error in Input Mysql Component '"+inputMysqlJaxb.getId()+"' Error! Can\'t proceed with partitioning");
-                throw new RuntimeException("Error in Input Mysql Component '"+inputMysqlJaxb.getId()+"' The lower bound is greater than upper bound");
+            if (inputMysqlJaxb.getNumPartitions().getLowerBound().getValue()
+                    .intValue() > inputMysqlJaxb.getNumPartitions().getUpperBound().getValue().intValue()) {
+                LOG.error("Error in Input Mysql Component '" + inputMysqlJaxb.getId() + "' Error! Can\'t proceed with partitioning");
+                throw new RuntimeException("Error in Input Mysql Component '" + inputMysqlJaxb.getId() + "' The lower bound is greater than upper bound");
 
             }
 
         }
         //fetchsize
-        inputRDBMSEntity.setFetchSize(inputMysqlJaxb.getFetchSize()==null?null: inputMysqlJaxb.getFetchSize().getValue());
+        inputRDBMSEntity.setFetchSize(inputMysqlJaxb.getFetchSize() == null ? null : inputMysqlJaxb.getFetchSize().getValue());
         //extra url parameters
-        //inputRDBMSEntity.setExtraUrlParameters(inputMysqlJaxb.getExtraUrlParams()==null?null:inputMysqlJaxb.getExtraUrlParams().getValue());
-        if(inputMysqlJaxb.getExtraUrlParams()!=null){
-            if(inputMysqlJaxb.getExtraUrlParams().getValue().contains(",")){
-                String correctedParams = inputMysqlJaxb.getExtraUrlParams().getValue().replaceAll("\\s+","").replace(",","&");
 
-                LOG.info("using extra url params as" + correctedParams);
+        if (inputMysqlJaxb.getExtraUrlParams() != null) {
+            String rawParam = inputMysqlJaxb.getExtraUrlParams().getValue();
+
+            Pattern regexForComma = Pattern.compile("([,]{0,1})");
+            Pattern regexForOthers = Pattern.compile("[$&:;?@#|'<>.^*()%+!]");
+            Pattern regexForRepitititons = Pattern.compile("([,]{2,})");
+
+            Matcher commaMatcher = regexForComma.matcher(rawParam);
+            Matcher otherCharMatcher = regexForOthers.matcher(rawParam);
+            Matcher doubleCharMatcher = regexForRepitititons.matcher(rawParam);
+
+
+
+            if(doubleCharMatcher.find()) {
+                throw new RuntimeException("Repeated comma found");
+            }
+            else if (otherCharMatcher.find()) {
+                throw new RuntimeException("Other delimiter found");
+            } else if (commaMatcher.find()) {
+               /*
+               * If the string happens to have a , then all the commas shall be replaced by &
+               * */
+                String correctedParams = rawParam.replaceAll(",", "&").replaceAll("(\\s+)","");
+                LOG.info("The extraUrlParams being used as"+ correctedParams );
                 inputRDBMSEntity.setExtraUrlParameters(correctedParams);
             }
-        }else if(inputMysqlJaxb.getExtraUrlParams()==null){
+            else {
+                String correctedParams = rawParam.replaceAll("(\\s+)","&");
+                LOG.info("The extraUrlParams being used as "+ correctedParams);
+                inputRDBMSEntity.setExtraUrlParameters(correctedParams);
+            }
+
+        } else {
+            LOG.info("extraUrlParameters initialized with null");
             inputRDBMSEntity.setExtraUrlParameters(null);
         }
 

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputOracleEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputOracleEntityGenerator.java
@@ -22,43 +22,43 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * The Class InputOracleEntityGenerator.
  *
  * @author Bitwise
- *
  */
 public class InputOracleEntityGenerator extends
-InputComponentGeneratorBase {
+        InputComponentGeneratorBase {
 
-	private static Logger LOG = LoggerFactory
-			.getLogger(InputOracleEntityGenerator.class);
+    private static Logger LOG = LoggerFactory
+            .getLogger(InputOracleEntityGenerator.class);
     private Oracle inputOracleJaxb;
     private InputRDBMSEntity inputRDBMSEntity;
 
-	public InputOracleEntityGenerator(TypeBaseComponent baseComponent) {
-		super(baseComponent);
-	}
+    public InputOracleEntityGenerator(TypeBaseComponent baseComponent) {
+        super(baseComponent);
+    }
 
-	
 
-	@Override
-	public void castComponentFromBase(TypeBaseComponent baseComponent) {
-		inputOracleJaxb = (Oracle) baseComponent;
-	}
+    @Override
+    public void castComponentFromBase(TypeBaseComponent baseComponent) {
+        inputOracleJaxb = (Oracle) baseComponent;
+    }
 
-	@Override
-	public void createEntity() {
-		inputRDBMSEntity = new InputRDBMSEntity();
-	}
+    @Override
+    public void createEntity() {
+        inputRDBMSEntity = new InputRDBMSEntity();
+    }
 
-	@Override
-	public void initializeEntity() {
+    @Override
+    public void initializeEntity() {
 
         LOG.trace("Initializing input file Oracle component: " + inputOracleJaxb.getId());
 
-		inputRDBMSEntity.setComponentId(inputOracleJaxb.getId());
+        inputRDBMSEntity.setComponentId(inputOracleJaxb.getId());
         inputRDBMSEntity.setFieldsList(InputEntityUtils.extractInputFields(
                 inputOracleJaxb.getOutSocket().get(0).getSchema().getFieldOrRecordOrIncludeExternalSchema()));
         inputRDBMSEntity.setOutSocketList(InputEntityUtils.extractOutSocket(inputOracleJaxb.getOutSocket()));
@@ -66,7 +66,7 @@ InputComponentGeneratorBase {
         inputRDBMSEntity.setHostName(inputOracleJaxb.getHostName().getValue());
         inputRDBMSEntity.setPort(inputOracleJaxb.getPort() == null ? Constants.ORACLE_PORT_NUMBER
                 : inputOracleJaxb.getPort().getValue().intValue());
-        inputRDBMSEntity.setRuntimeProperties(inputOracleJaxb.getRuntimeProperties() == null ? new Properties():InputEntityUtils
+        inputRDBMSEntity.setRuntimeProperties(inputOracleJaxb.getRuntimeProperties() == null ? new Properties() : InputEntityUtils
                 .extractRuntimeProperties(inputOracleJaxb.getRuntimeProperties()));
         inputRDBMSEntity.setBatch(inputOracleJaxb.getBatch());
         if (inputOracleJaxb.getSelectQuery() != null) {
@@ -90,8 +90,8 @@ InputComponentGeneratorBase {
             inputRDBMSEntity.setSchemaName(null);
         }
         /**new parameters that has been added after the open source release*/
-        inputRDBMSEntity.setNumPartitionsValue(inputOracleJaxb.getNumPartitions() == null? Integer.MIN_VALUE:inputOracleJaxb.getNumPartitions().getValue().intValue());
-        if(inputOracleJaxb.getNumPartitions()!=null&&inputOracleJaxb.getNumPartitions().getValue().intValue()==0){
+        inputRDBMSEntity.setNumPartitionsValue(inputOracleJaxb.getNumPartitions() == null ? Integer.MIN_VALUE : inputOracleJaxb.getNumPartitions().getValue().intValue());
+        if (inputOracleJaxb.getNumPartitions() != null && inputOracleJaxb.getNumPartitions().getValue().intValue() == 0) {
             LOG.warn("The number of partitions has been entered as ZERO," +
                     "\nThe Execution shall still continue but will work on a single" +
                     "\npartition hence impacting performance");
@@ -104,61 +104,84 @@ InputComponentGeneratorBase {
          *          the values from the below parameters listed and the second one which does partitoning accepts the
          *          aforementioned parameters. Absence of any one parameter may lead to undesirable outcomes
          * */
-        if(inputOracleJaxb.getNumPartitions()==null){
+        if (inputOracleJaxb.getNumPartitions() == null) {
             inputRDBMSEntity.setUpperBound(0);
             inputRDBMSEntity.setLowerBound(0);
             inputRDBMSEntity.setColumnName("");
-        }
-        else {
+        } else {
             if (inputOracleJaxb.getNumPartitions().getUpperBound() == null) {
-                throw new RuntimeException("Error in Input Oracle Component '"+inputOracleJaxb.getId()+"'  Upper bound cannot be NULL when numPartitions holds an integer value");
-            } else inputRDBMSEntity.setUpperBound(inputOracleJaxb.getNumPartitions().getUpperBound().getValue().intValue());
+                throw new RuntimeException("Error in Input Oracle Component '" + inputOracleJaxb.getId() + "'  Upper bound cannot be NULL when numPartitions holds an integer value");
+            } else
+                inputRDBMSEntity.setUpperBound(inputOracleJaxb.getNumPartitions().getUpperBound().getValue().intValue());
 
             if (inputOracleJaxb.getNumPartitions().getLowerBound() == null) {
-                throw new RuntimeException("Error in Input Oracle Component '"+inputOracleJaxb.getId()+"'  Lower bound cannot be NULL when numPartitions holds an integer value");
-            } else inputRDBMSEntity.setLowerBound(inputOracleJaxb.getNumPartitions().getLowerBound().getValue().intValue());
+                throw new RuntimeException("Error in Input Oracle Component '" + inputOracleJaxb.getId() + "'  Lower bound cannot be NULL when numPartitions holds an integer value");
+            } else
+                inputRDBMSEntity.setLowerBound(inputOracleJaxb.getNumPartitions().getLowerBound().getValue().intValue());
 
             if (inputOracleJaxb.getNumPartitions().getColumnName() == null) {
-                throw new RuntimeException("Error in Input Oracle Component '"+inputOracleJaxb.getId()+"' Column Name cannot be NULL when numPartitions holds an integer value");
+                throw new RuntimeException("Error in Input Oracle Component '" + inputOracleJaxb.getId() + "' Column Name cannot be NULL when numPartitions holds an integer value");
             } else inputRDBMSEntity.setColumnName(inputOracleJaxb.getNumPartitions().getColumnName().getValue());
 
-            if(inputOracleJaxb.getNumPartitions().getLowerBound().getValue()
-                    .intValue()==inputOracleJaxb.getNumPartitions().getUpperBound().getValue().intValue()){
-                LOG.warn("'"+inputOracleJaxb.getId()+"'The upper bound and the lower bound values are same! In this case there will only be\n" +
+            if (inputOracleJaxb.getNumPartitions().getLowerBound().getValue()
+                    .intValue() == inputOracleJaxb.getNumPartitions().getUpperBound().getValue().intValue()) {
+                LOG.warn("'" + inputOracleJaxb.getId() + "'The upper bound and the lower bound values are same! In this case there will only be\n" +
                         "a single partition");
             }
-            if(inputOracleJaxb.getNumPartitions().getLowerBound().getValue()
-                    .intValue()>inputOracleJaxb.getNumPartitions().getUpperBound().getValue().intValue()){
-                LOG.error("Error in Input Oracle Component '"+inputOracleJaxb.getId()+"'  Can\'t proceed with partitioning");
-                throw new RuntimeException("Error in Input Oracle Component '"+inputOracleJaxb.getId()+"'  The lower bound is greater than upper bound");
+            if (inputOracleJaxb.getNumPartitions().getLowerBound().getValue()
+                    .intValue() > inputOracleJaxb.getNumPartitions().getUpperBound().getValue().intValue()) {
+                LOG.error("Error in Input Oracle Component '" + inputOracleJaxb.getId() + "'  Can\'t proceed with partitioning");
+                throw new RuntimeException("Error in Input Oracle Component '" + inputOracleJaxb.getId() + "'  The lower bound is greater than upper bound");
 
             }
 
         }
         //fetchsize
-        inputRDBMSEntity.setFetchSize(inputOracleJaxb.getFetchSize()==null?null: inputOracleJaxb.getFetchSize().getValue());
+        inputRDBMSEntity.setFetchSize(inputOracleJaxb.getFetchSize() == null ? null : inputOracleJaxb.getFetchSize().getValue());
         //extra url parameters
 
-        if(inputOracleJaxb.getExtraUrlParams()!=null){
-            if(inputOracleJaxb.getExtraUrlParams().getValue().contains(",")){
-                String correctedParams = inputOracleJaxb.getExtraUrlParams().getValue().replaceAll("\\s+","").replace(",","&");
+        if (inputOracleJaxb.getExtraUrlParams() != null) {
+            String rawParam = inputOracleJaxb.getExtraUrlParams().getValue();
 
-                LOG.info("using extra url params as" + correctedParams);
+            Pattern regexForComma = Pattern.compile("([,]{0,1})");
+            Pattern regexForOthers = Pattern.compile("[$&:;?@#|'<>.^*()%+!]");
+            Pattern regexForRepitititons = Pattern.compile("([,]{2,})");
+
+            Matcher commaMatcher = regexForComma.matcher(rawParam);
+            Matcher otherCharMatcher = regexForOthers.matcher(rawParam);
+            Matcher doubleCharMatcher = regexForRepitititons.matcher(rawParam);
+
+
+
+            if(doubleCharMatcher.find()) {
+                throw new RuntimeException("Repeated comma found");
+            }
+            else if (otherCharMatcher.find()) {
+                throw new RuntimeException("Other delimiter found");
+            } else if (commaMatcher.find()) {
+               /*
+               * If the string happens to have a , then all the commas shall be replaced by &
+               * */
+                String correctedParams = rawParam.replaceAll(",", "&").replaceAll("(\\s+)","");
+                LOG.info("The extraUrlParams being used as"+ correctedParams );
                 inputRDBMSEntity.setExtraUrlParameters(correctedParams);
             }
-        }else if(inputOracleJaxb.getExtraUrlParams()==null){
+            else {
+                String correctedParams = rawParam.replaceAll("(\\s+)","&");
+                LOG.info("The extraUrlParams being used as "+ correctedParams);
+                inputRDBMSEntity.setExtraUrlParameters(correctedParams);
+            }
+
+        } else {
+            LOG.info("extraUrlParameters initialized with null");
             inputRDBMSEntity.setExtraUrlParameters(null);
         }
-
         /**END*/
     }
 
 
-	
-	
-
-	@Override
-	public InputRDBMSEntity getEntity() {
-		return inputRDBMSEntity;
-	}
+    @Override
+    public InputRDBMSEntity getEntity() {
+        return inputRDBMSEntity;
+    }
 }

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputOracleEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputOracleEntityGenerator.java
@@ -138,7 +138,17 @@ InputComponentGeneratorBase {
         //fetchsize
         inputRDBMSEntity.setFetchSize(inputOracleJaxb.getFetchSize()==null?null: inputOracleJaxb.getFetchSize().getValue());
         //extra url parameters
-        inputRDBMSEntity.setExtraUrlParameters(inputOracleJaxb.getExtraUrlParams()==null?null:inputOracleJaxb.getExtraUrlParams().getValue());
+
+        if(inputOracleJaxb.getExtraUrlParams()!=null){
+            if(inputOracleJaxb.getExtraUrlParams().getValue().contains(",")){
+                String correctedParams = inputOracleJaxb.getExtraUrlParams().getValue().replaceAll("\\s+","").replace(",","&");
+
+                LOG.info("using extra url params as" + correctedParams);
+                inputRDBMSEntity.setExtraUrlParameters(correctedParams);
+            }
+        }else if(inputOracleJaxb.getExtraUrlParams()==null){
+            inputRDBMSEntity.setExtraUrlParameters(null);
+        }
 
         /**END*/
     }

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputTeradataEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputTeradataEntityGenerator.java
@@ -126,7 +126,17 @@ public class InputTeradataEntityGenerator extends
         //fetchsize
         inputRDBMSEntity.setFetchSize(inputTeradataJaxb.getFetchSize()==null?null: inputTeradataJaxb.getFetchSize().getValue());
         //extra url parameters
-        inputRDBMSEntity.setExtraUrlParameters(inputTeradataJaxb.getExtraUrlParams()==null?null:inputTeradataJaxb.getExtraUrlParams().getValue());
+        if(inputTeradataJaxb.getExtraUrlParams()!=null){
+            if(inputTeradataJaxb.getExtraUrlParams().getValue().contains(",")){
+                String correctedParams = inputTeradataJaxb.getExtraUrlParams().getValue().replaceAll("\\s+","");
+
+                LOG.info("using extra url params as" + correctedParams);
+                inputRDBMSEntity.setExtraUrlParameters(correctedParams);
+            }
+        }else if(inputTeradataJaxb.getExtraUrlParams()==null){
+            inputRDBMSEntity.setExtraUrlParameters(null);
+        }
+
 
         /**END*/
         inputRDBMSEntity.setDatabaseType("Teradata");

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputTeradataEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/InputTeradataEntityGenerator.java
@@ -23,6 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * The Class InputTeradataEntityGenerator.
  *
@@ -126,17 +129,42 @@ public class InputTeradataEntityGenerator extends
         //fetchsize
         inputRDBMSEntity.setFetchSize(inputTeradataJaxb.getFetchSize()==null?null: inputTeradataJaxb.getFetchSize().getValue());
         //extra url parameters
-        if(inputTeradataJaxb.getExtraUrlParams()!=null){
-            if(inputTeradataJaxb.getExtraUrlParams().getValue().contains(",")){
-                String correctedParams = inputTeradataJaxb.getExtraUrlParams().getValue().replaceAll("\\s+","");
+        if (inputTeradataJaxb.getExtraUrlParams() != null) {
+            String rawParam = inputTeradataJaxb.getExtraUrlParams().getValue();
 
-                LOG.info("using extra url params as" + correctedParams);
+            Pattern regexForComma = Pattern.compile("([,]{0,1})");
+            Pattern regexForOthers = Pattern.compile("[$&:;?@#|'<>.^*()%+!]");
+            Pattern regexForRepitititons = Pattern.compile("([,]{2,})");
+
+            Matcher commaMatcher = regexForComma.matcher(rawParam);
+            Matcher otherCharMatcher = regexForOthers.matcher(rawParam);
+            Matcher doubleCharMatcher = regexForRepitititons.matcher(rawParam);
+
+
+
+            if(doubleCharMatcher.find()) {
+                throw new RuntimeException("Repeated comma found");
+            }
+            else if (otherCharMatcher.find()) {
+                throw new RuntimeException("Other delimiter found");
+            } else if (commaMatcher.find()) {
+               /*
+               * If the string happens to have a , then all the commas shall be replaced by &
+               * */
+                String correctedParams = rawParam.replaceAll("(\\s+)","");
+                LOG.info("The extraUrlParams being used as"+ correctedParams );
                 inputRDBMSEntity.setExtraUrlParameters(correctedParams);
             }
-        }else if(inputTeradataJaxb.getExtraUrlParams()==null){
+            else {
+                String correctedParams = rawParam.replaceAll("(\\s+)","&");
+                LOG.info("The extraUrlParams being used as "+ correctedParams);
+                inputRDBMSEntity.setExtraUrlParameters(correctedParams);
+            }
+
+        } else {
+            LOG.info("extraUrlParameters initialized with null");
             inputRDBMSEntity.setExtraUrlParameters(null);
         }
-
 
         /**END*/
         inputRDBMSEntity.setDatabaseType("Teradata");

--- a/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/OutputTeradataEntityGenerator.java
+++ b/hydrograph.engine/hydrograph.engine.core/src/main/java/hydrograph/engine/core/component/generator/OutputTeradataEntityGenerator.java
@@ -23,6 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * The Class OutputTeradataEntityGenerator.
  *
@@ -107,7 +110,42 @@ public class OutputTeradataEntityGenerator extends OutputComponentGeneratorBase 
         //for batchsize which was named to chunksize since there is batch in the ETL tool as well
         outputRDBMSEntity.setChunkSize(jaxbOutputTeradata.getChunkSize()==null?null:jaxbOutputTeradata.getChunkSize().getValue());
         //extra url parameters has been
-        outputRDBMSEntity.setExtraUrlParamters(jaxbOutputTeradata.getExtraUrlParams()==null?null:jaxbOutputTeradata.getExtraUrlParams().getValue());
+        if (jaxbOutputTeradata.getExtraUrlParams() != null) {
+            String rawParam = jaxbOutputTeradata.getExtraUrlParams().getValue();
+
+            Pattern regexForComma = Pattern.compile("([,]{0,1})");
+            Pattern regexForOthers = Pattern.compile("[$&:;?@#|'<>.^*()%+!]");
+            Pattern regexForRepitititons = Pattern.compile("([,]{2,})");
+
+            Matcher commaMatcher = regexForComma.matcher(rawParam);
+            Matcher otherCharMatcher = regexForOthers.matcher(rawParam);
+            Matcher doubleCharMatcher = regexForRepitititons.matcher(rawParam);
+
+
+
+            if(doubleCharMatcher.find()) {
+                throw new RuntimeException("Repeated comma found");
+            }
+            else if (otherCharMatcher.find()) {
+                throw new RuntimeException("Other delimiter found");
+            } else if (commaMatcher.find()) {
+               /*
+               * If the string happens to have a , then all the commas shall be replaced by &
+               * */
+                String correctedParams = rawParam.replaceAll("(\\s+)","");
+                LOG.info("The extraUrlParams being used as"+ correctedParams );
+                outputRDBMSEntity.setExtraUrlParamters(correctedParams);
+            }
+            else {
+                String correctedParams = rawParam.replaceAll("(\\s+)","&");
+                LOG.info("The extraUrlParams being used as "+ correctedParams);
+                outputRDBMSEntity.setExtraUrlParamters(correctedParams);
+            }
+
+        } else {
+            LOG.info("extraUrlParameters initialized with null");
+            outputRDBMSEntity.setExtraUrlParamters(null);
+        }
         /**end**/
     }
 


### PR DESCRIPTION
Made changes to the entity generators of the DB components Oracle, MySQL and Teradata for validating the extra Url parameters such that the same can trim out spaces from the parameter and also added some more validations for the same such as the format of the value for extraUrlParameters is 
**param1 = value1,param2 = value2**
the new validation logic leverages regular expressions to not only trim out spaces which may be counter-productive for the execution to go on smoothly but also checks for the following aspects that

- Ensures there is a single delimiter between two parameters along with their values
- Ensures that any other special character other than comma(',') or equal ('=') is not accepted by the tool
