### PR TITLE
fixing Database component's additional parameter related bugs.

### DIFF
--- a/hydrograph.ui/hydrograph.ui.common/src/main/java/hydrograph/ui/common/util/Constants.java
+++ b/hydrograph.ui/hydrograph.ui.common/src/main/java/hydrograph/ui/common/util/Constants.java
@@ -61,7 +61,7 @@ public class Constants {
 	public static final String PARAMETER_REGEX ="^[\\@]{1}[\\{]{1}[\\s\\S]+[\\}]{1}";
 	
 	//Used for validating AlphaNumeric with , and = operator or Parameter E.g Aplha_123 or @{Param_123} or i = 10, j=20
-	public static final String DB_REGEX = "[\\@]{1}[\\{]{1}[\\w]*[\\}]{1}||[\\w,\\=]*";
+	public static final String DB_REGEX = "[\\@]{1}[\\{]{1}[\\w]*[\\}]{1}||[\\w,\\=,\\s]*";
 
 	// Used for validating AlphaNumeric or Parameter E.g Aplha_123
 	public static final String REGEX_ALPHA_NUMERIC = "[\\w]*";

--- a/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/Release_Notes_May_2017.txt
+++ b/hydrograph.ui/hydrograph.ui.product/resources/Release_Notes/Release_Notes_May_2017.txt
@@ -8,3 +8,10 @@ Issues/Defects fixed:
 Sr.No.  <GitHub Issue #>  - [fixed by]   - description
 1. <> - [Ankit Sharma] - Removed UTF-16 from Charset drop down bar.
 2. <> - [Ankit Sharma] - Replaced unknown component with dummy component. Also,added jaxb classes of it.
+3. <> - [Kalyan Rajpoot] - Database component: Error bubble is getting displayed when user provides value of Additional DB parameters with space.
+4. <> - [Kalyan Rajpoot] - 3(i) The upper bound and lower bound text boxes’ position should be interchanged.
+                         - 3(ii) Window should be resizable and the text boxes should expand / resize as per the window.
+                         - 3(iii) Reduce unnecessary space between label and text box and the space above buttons.
+5. <> - [Kalyan Rajpoot] - 	Database component: Property help text should be displayed for all additional parameter fields.
+6. <> - [Kalyan Rajpoot] -  Database Component: Dropdown should be present for Partition key field under Additional Parameters window.                              
+

--- a/hydrograph.ui/hydrograph.ui.propertywindow/resources/messages.properties
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/resources/messages.properties
@@ -427,3 +427,7 @@ LOWER_BOUND_LABEL=Specify the minimum value of partition key
 FETCH_SIZE_PARAM=Specify number of rows that will be fetched from database per network round trip
 ADDITIONAL_DB_PARAMETER=Specify additional parameters for JDBC URL
 CHUNK_SIZE=Specify number of rows that will be loaded to database per network round trip
+#Load Configuration
+LOADCONFIG_NEWTABLE=For creating the new table on DB 
+LOADCONFIG_INSERT=For inserting the data into the table that already present on DB
+LOADCONFIG_REPLACE=For replacing the table that already present on DB

--- a/hydrograph.ui/hydrograph.ui.propertywindow/resources/messages.properties
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/resources/messages.properties
@@ -418,3 +418,12 @@ DB_NUMERIC_PARAMETERZIATION_ERROR=Accepts only numeric or Parameter values Ex: 1
 ADDITIONAL_PARAMETERS_FOR_DB_WINDOW_LABEL=Additional Parameters
 UPPER_LOWER_BOUND_ERROR=Upper Bound should be greater than lower bound.
 ADDITIONAL_PARAMETERS_FOR_DB_LABEL=Additional\nParameters
+
+#Addtional Parametes of DB Component
+NUMBER_OF_PARTITIONS=Specify number of parallel instances to be run
+PARTITONS_KEY=Specify the field of integer type that will be used for partitioning
+UPPER_BOUND_LABEL=Specify the maximum value of partition key 
+LOWER_BOUND_LABEL=Specify the minimum value of partition key
+FETCH_SIZE_PARAM=Specify number of rows that will be fetched from database per network round trip
+ADDITIONAL_DB_PARAMETER=Specify additional parameters for JDBC URL
+CHUNK_SIZE=Specify number of rows that will be loaded to database per network round trip

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/messages/Messages.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/messages/Messages.java
@@ -432,6 +432,10 @@ public class Messages extends NLS {
 	public static String ADDITIONAL_DB_PARAMETER;
 	public static String CHUNK_SIZE;
 	
+	public static String LOADCONFIG_NEWTABLE;
+	public static String LOADCONFIG_INSERT;
+	public static String LOADCONFIG_REPLACE;
+	
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/messages/Messages.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/messages/Messages.java
@@ -424,6 +424,13 @@ public class Messages extends NLS {
 	public static String UPPER_LOWER_BOUND_ERROR;
 	public static String ADDITIONAL_PARAMETERS_FOR_DB_LABEL;
 	
+	public static String NUMBER_OF_PARTITIONS;
+	public static String PARTITONS_KEY;
+	public static String UPPER_BOUND_LABEL;
+	public static String LOWER_BOUND_LABEL;
+	public static String FETCH_SIZE_PARAM;
+	public static String ADDITIONAL_DB_PARAMETER;
+	public static String CHUNK_SIZE;
 	
 	static {
 		// initialize resource bundle

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
@@ -185,22 +185,6 @@ public class InputAdditionalParametersDialog extends Dialog {
 			partitionKeyComboBox.select(0);
 		}
 		
-		partitionKeyUpperBoundLabel = new Label(composite, SWT.NONE);
-		GridData gd_partitionKeyUpperBoundLabel = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-		gd_partitionKeyUpperBoundLabel.widthHint = 180;
-		partitionKeyUpperBoundLabel.setLayoutData(gd_partitionKeyUpperBoundLabel);
-		partitionKeyUpperBoundLabel.setText(Messages.PARTITION_KEY_UPPER_BOUND);
-
-		partitionKeyUpperBoundTextBox = new Text(composite, SWT.BORDER);
-		partitionKeyUpperBoundControlDecoration = WidgetUtility.addDecorator(partitionKeyUpperBoundTextBox,
-				Messages.DB_NUMERIC_PARAMETERZIATION_ERROR);
-		partitionKeyUpperBoundControlDecoration.setMarginWidth(2);
-		partitionKeyUpperBoundControlDecoration.hide();
-		GridData gd_partitionKeyUpperBoundTextBox = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
-		gd_partitionKeyUpperBoundTextBox.horizontalIndent = 10;
-		partitionKeyUpperBoundTextBox.setLayoutData(gd_partitionKeyUpperBoundTextBox);
-		partitionKeyUpperBoundTextBox.setEnabled(false);
-
 		partitionKeyLowerBoundLabel = new Label(composite, SWT.NONE);
 		GridData gd_partitionKeyLowerBoundLabel = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
 		gd_partitionKeyLowerBoundLabel.widthHint = 180;
@@ -216,6 +200,22 @@ public class InputAdditionalParametersDialog extends Dialog {
 		gd_partitionKeyLowerBoundTextBox.horizontalIndent = 10;
 		partitionKeyLowerBoundTextBox.setLayoutData(gd_partitionKeyLowerBoundTextBox);
 		partitionKeyLowerBoundTextBox.setEnabled(false);
+		
+		partitionKeyUpperBoundLabel = new Label(composite, SWT.NONE);
+		GridData gd_partitionKeyUpperBoundLabel = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
+		gd_partitionKeyUpperBoundLabel.widthHint = 180;
+		partitionKeyUpperBoundLabel.setLayoutData(gd_partitionKeyUpperBoundLabel);
+		partitionKeyUpperBoundLabel.setText(Messages.PARTITION_KEY_UPPER_BOUND);
+
+		partitionKeyUpperBoundTextBox = new Text(composite, SWT.BORDER);
+		partitionKeyUpperBoundControlDecoration = WidgetUtility.addDecorator(partitionKeyUpperBoundTextBox,
+				Messages.DB_NUMERIC_PARAMETERZIATION_ERROR);
+		partitionKeyUpperBoundControlDecoration.setMarginWidth(2);
+		partitionKeyUpperBoundControlDecoration.hide();
+		GridData gd_partitionKeyUpperBoundTextBox = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
+		gd_partitionKeyUpperBoundTextBox.horizontalIndent = 10;
+		partitionKeyUpperBoundTextBox.setLayoutData(gd_partitionKeyUpperBoundTextBox);
+		partitionKeyUpperBoundTextBox.setEnabled(false);
 
 		fetchSizeLabel = new Label(composite, SWT.NONE);
 		GridData gd_fetchSizeLabel = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
@@ -27,8 +27,6 @@ import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
-import org.eclipse.swt.events.KeyAdapter;
-import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -49,6 +47,7 @@ import org.slf4j.Logger;
 
 import hydrograph.ui.common.util.Constants;
 import hydrograph.ui.logging.factory.LogFactory;
+import hydrograph.ui.propertywindow.handlers.ShowHidePropertyHelpHandler;
 import hydrograph.ui.propertywindow.messages.Messages;
 import hydrograph.ui.propertywindow.propertydialog.PropertyDialogButtonBar;
 import hydrograph.ui.propertywindow.utils.Utils;
@@ -92,6 +91,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 	private ControlDecoration additionalParameterControlDecoration;
 	//private ControlDecoration partitionKeyControlDecoration;
 	private Cursor cursor;
+	private boolean ShowHidePropertyHelpChecked;
 
 	/**
 	 * Create the dialog.
@@ -117,6 +117,8 @@ public class InputAdditionalParametersDialog extends Dialog {
 		this.additionalParameterValue = initialMap;
 		this.cursor = cursor;
 	}
+	
+	
 
 	/**
 	 * Create contents of the dialog.
@@ -143,8 +145,6 @@ public class InputAdditionalParametersDialog extends Dialog {
             }
         });
 		
-		
-		
 		Composite composite = new Composite(container, SWT.NONE);
 		composite.setLayout(new GridLayout(2, false));
 		composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
@@ -154,7 +154,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 		gd_noOfPartitionsLabel.widthHint = 180;
 		noOfPartitionsLabel.setLayoutData(gd_noOfPartitionsLabel);
 		noOfPartitionsLabel.setText(Messages.NO_OF_PARTITIONS);
-
+		
 		noOfPartitionsTextBox = new Text(composite, SWT.BORDER);
 		noOfPartitionControlDecoration = WidgetUtility.addDecorator(noOfPartitionsTextBox,
 				Messages.DB_NUMERIC_PARAMETERZIATION_ERROR);
@@ -169,7 +169,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 		gd_partitionKeysLabel.widthHint = 180;
 		partitionKeysLabel.setLayoutData(gd_partitionKeysLabel);
 		partitionKeysLabel.setText(Messages.PARTITION_KEY);
-
+		
 		partitionKeyButton = new Combo(composite, SWT.DROP_DOWN);
 		partitionKeyButton.setItems(convertToArray(schemaFields));
 		GridData gd_partitionKeyButton = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
@@ -206,7 +206,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 		gd_partitionKeyLowerBoundLabel.widthHint = 180;
 		partitionKeyLowerBoundLabel.setLayoutData(gd_partitionKeyLowerBoundLabel);
 		partitionKeyLowerBoundLabel.setText(Messages.PARTITION_KEY_LOWER_BOUND);
-
+		
 		partitionKeyLowerBoundTextBox = new Text(composite, SWT.BORDER);
 		partitionKeyLowerBoundControlDecoration = WidgetUtility.addDecorator(partitionKeyLowerBoundTextBox,
 				Messages.DB_NUMERIC_PARAMETERZIATION_ERROR);
@@ -222,7 +222,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 		gd_fetchSizeLabel.widthHint = 180;
 		fetchSizeLabel.setLayoutData(gd_fetchSizeLabel);
 		fetchSizeLabel.setText(Messages.FETCH_SIZE);
-
+		
 		fetchSizeTextBox = new Text(composite, SWT.BORDER);
 		fetchSizeControlDecoration = WidgetUtility.addDecorator(fetchSizeTextBox,
 				Messages.FETCH_SIZE_ERROR_DECORATOR_MESSAGE);
@@ -271,7 +271,36 @@ public class InputAdditionalParametersDialog extends Dialog {
 
 		getShell().setMinimumSize(getInitialSize());
 		
+		setPropertyHelpText();
+		
 		return container;
+	}
+
+
+
+	private void setPropertyHelpText() {
+		if(ShowHidePropertyHelpHandler.getInstance() != null)
+		ShowHidePropertyHelpChecked = ShowHidePropertyHelpHandler.getInstance().isShowHidePropertyHelpChecked();
+		
+		if(ShowHidePropertyHelpChecked){
+			noOfPartitionsLabel.setToolTipText(Messages.NUMBER_OF_PARTITIONS);
+			noOfPartitionsLabel.setCursor(new Cursor(noOfPartitionsLabel.getDisplay(), SWT.CURSOR_HELP));
+			
+			partitionKeysLabel.setToolTipText(Messages.PARTITONS_KEY);
+			partitionKeysLabel.setCursor(new Cursor(partitionKeysLabel.getDisplay(), SWT.CURSOR_HELP));
+			
+			partitionKeyUpperBoundLabel.setToolTipText(Messages.UPPER_BOUND_LABEL);
+			partitionKeyUpperBoundLabel.setCursor(new Cursor(partitionKeyUpperBoundLabel.getDisplay(), SWT.CURSOR_HELP));
+			
+			partitionKeyLowerBoundLabel.setToolTipText(Messages.LOWER_BOUND_LABEL);
+			partitionKeyLowerBoundLabel.setCursor(new Cursor(partitionKeyLowerBoundLabel.getDisplay(), SWT.CURSOR_HELP));
+			
+			fetchSizeLabel.setToolTipText(Messages.FETCH_SIZE_PARAM);
+			fetchSizeLabel.setCursor(new Cursor(fetchSizeLabel.getDisplay(), SWT.CURSOR_HELP));
+			
+			additionalDBParametersLabel.setToolTipText(Messages.ADDITIONAL_DB_PARAMETER);
+			additionalDBParametersLabel.setCursor(new Cursor(additionalDBParametersLabel.getDisplay(), SWT.CURSOR_HELP));
+			}
 	}
 
 	private void addModifyListener(Text text){

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
@@ -458,12 +458,4 @@ public class InputAdditionalParametersDialog extends Dialog {
 		super.okPressed();
 	}
 	
-	private String[] convertToArray(List<String> items) {
-		String[] stringItemsList = new String[items.size()];
-		int index = 0;
-		for (String item : items) {
-			stringItemsList[index++] = item;
-		}
-		return stringItemsList;
-		}
-	}
+}

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
@@ -78,7 +78,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 	private Label additionalDBParametersLabel;
 	protected String selectedPartitionKey;
 	protected Map<String, String> runtimeValueMap;
-	private Combo partitionKeyButton;
+	private Combo partitionKeyComboBox;
 	private ControlDecoration noOfPartitionControlDecoration;
 	private ControlDecoration partitionKeyUpperBoundControlDecoration;
 	private ControlDecoration partitionKeyLowerBoundControlDecoration;
@@ -102,7 +102,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 			PropertyDialogButtonBar propertyDialogButtonBar, List<String> schemaFields,
 			Map<String, Object> initialMap, Cursor cursor) {
 		super(parentShell);
-		setShellStyle(SWT.CLOSE | SWT.TITLE | SWT.WRAP | SWT.APPLICATION_MODAL | SWT.SHELL_TRIM);
+		setShellStyle(SWT.CLOSE | SWT.TITLE | SWT.WRAP | SWT.APPLICATION_MODAL | SWT.RESIZE);
 		if (StringUtils.isNotBlank(windowTitle))
 			windowLabel = windowTitle;
 		else
@@ -165,21 +165,24 @@ public class InputAdditionalParametersDialog extends Dialog {
 		partitionKeysLabel.setLayoutData(gd_partitionKeysLabel);
 		partitionKeysLabel.setText(Messages.PARTITION_KEY);
 		
-		partitionKeyButton = new Combo(composite, SWT.DROP_DOWN);
-		partitionKeyButton.setItems(convertToArray(schemaFields));
+		partitionKeyComboBox = new Combo(composite, SWT.DROP_DOWN);
+		partitionKeyComboBox.setItems(convertToArray(schemaFields));
 		GridData gd_partitionKeyButton = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-		partitionKeyButton.setVisibleItemCount(11);
-		partitionKeyButton.setEnabled(false);
+		partitionKeyComboBox.setVisibleItemCount(11);
+		partitionKeyComboBox.setEnabled(false);
 		
 		gd_partitionKeyButton.widthHint = 90;
 		gd_partitionKeyButton.horizontalIndent = 10;
-		partitionKeyButton.setLayoutData(gd_partitionKeyButton);
+		partitionKeyComboBox.setLayoutData(gd_partitionKeyButton);
 		
-		new AutoCompleteField(partitionKeyButton, new ComboContentAdapter(), convertToArray(schemaFields));
+		new AutoCompleteField(partitionKeyComboBox, new ComboContentAdapter(), convertToArray(schemaFields));
 		
 		selectedPartitionKey = (String) additionalParameterValue.get(Constants.DB_PARTITION_KEY);
 		if(selectedPartitionKey != null){
-		partitionKeyButton.setText(selectedPartitionKey);
+		partitionKeyComboBox.setText(selectedPartitionKey);
+		}
+		else{
+			partitionKeyComboBox.select(0);
 		}
 		
 		partitionKeyUpperBoundLabel = new Label(composite, SWT.NONE);
@@ -329,7 +332,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 
 			@Override
 			public void modifyText(ModifyEvent event) {
-				partitionKeyButton.setEnabled(true);
+				partitionKeyComboBox.setEnabled(true);
 				partitionKeyLowerBoundTextBox.setEnabled(true);
 				partitionKeyUpperBoundTextBox.setEnabled(true);
 				if (StringUtils.isNotBlank(noOfPartitionsTextBox.getText())) {
@@ -340,7 +343,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 				}else{
 					partitionKeyLowerBoundControlDecoration.hide();
 					partitionKeyUpperBoundControlDecoration.hide();
-					partitionKeyButton.setEnabled(false);
+					partitionKeyComboBox.setEnabled(false);
 					partitionKeyLowerBoundTextBox.setEnabled(false);
 					partitionKeyUpperBoundTextBox.setEnabled(false);
 				}
@@ -354,7 +357,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 			public void focusLost(FocusEvent e) {
 				if (StringUtils.isBlank(noOfPartitionsTextBox.getText())
 						&& StringUtils.isEmpty(noOfPartitionsTextBox.getText())) {
-					partitionKeyButton.setEnabled(false);
+					partitionKeyComboBox.setEnabled(false);
 					partitionKeyLowerBoundTextBox.setEnabled(false);
 					partitionKeyUpperBoundTextBox.setEnabled(false);
 				}
@@ -365,7 +368,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 
 				if (StringUtils.isNotBlank(noOfPartitionsTextBox.getText())
 						&& StringUtils.isNotEmpty(noOfPartitionsTextBox.getText())) {
-					partitionKeyButton.setEnabled(true);
+					partitionKeyComboBox.setEnabled(true);
 					partitionKeyLowerBoundTextBox.setEnabled(true);
 					partitionKeyUpperBoundTextBox.setEnabled(true);
 				}
@@ -443,7 +446,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 		additionalParameterValue= new LinkedHashMap<>();
 		if (StringUtils.isNotBlank(noOfPartitionsTextBox.getText())) {
 			additionalParameterValue.put(Constants.NUMBER_OF_PARTITIONS, noOfPartitionsTextBox.getText());
-			additionalParameterValue.put(Constants.DB_PARTITION_KEY, partitionKeyButton.getText());
+			additionalParameterValue.put(Constants.DB_PARTITION_KEY, partitionKeyComboBox.getText());
 			additionalParameterValue.put(Constants.NOP_UPPER_BOUND, partitionKeyUpperBoundTextBox.getText());
 			additionalParameterValue.put(Constants.NOP_LOWER_BOUND, partitionKeyLowerBoundTextBox.getText());
 		}else{

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
@@ -29,14 +29,11 @@ import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -51,7 +48,6 @@ import hydrograph.ui.propertywindow.handlers.ShowHidePropertyHelpHandler;
 import hydrograph.ui.propertywindow.messages.Messages;
 import hydrograph.ui.propertywindow.propertydialog.PropertyDialogButtonBar;
 import hydrograph.ui.propertywindow.utils.Utils;
-import hydrograph.ui.propertywindow.widgets.dialogs.FieldDialogForDBComponents;
 import hydrograph.ui.propertywindow.widgets.listeners.ExtraURLParameterValidationForDBComponents;
 import hydrograph.ui.propertywindow.widgets.listeners.ListenerHelper;
 import hydrograph.ui.propertywindow.widgets.listeners.ListenerHelper.HelperType;
@@ -89,7 +85,6 @@ public class InputAdditionalParametersDialog extends Dialog {
 	private ControlDecoration fetchSizeControlDecoration;
 	private Text additionalParameterTextBox;
 	private ControlDecoration additionalParameterControlDecoration;
-	//private ControlDecoration partitionKeyControlDecoration;
 	private Cursor cursor;
 	private boolean ShowHidePropertyHelpChecked;
 
@@ -179,12 +174,14 @@ public class InputAdditionalParametersDialog extends Dialog {
 		gd_partitionKeyButton.widthHint = 90;
 		gd_partitionKeyButton.horizontalIndent = 10;
 		partitionKeyButton.setLayoutData(gd_partitionKeyButton);
-		partitionKeyButton.select(0);
 		
 		new AutoCompleteField(partitionKeyButton, new ComboContentAdapter(), convertToArray(schemaFields));
 		
 		selectedPartitionKey = (String) additionalParameterValue.get(Constants.DB_PARTITION_KEY);
-
+		if(selectedPartitionKey != null){
+		partitionKeyButton.setText(selectedPartitionKey);
+		}
+		
 		partitionKeyUpperBoundLabel = new Label(composite, SWT.NONE);
 		GridData gd_partitionKeyUpperBoundLabel = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
 		gd_partitionKeyUpperBoundLabel.widthHint = 180;
@@ -248,8 +245,6 @@ public class InputAdditionalParametersDialog extends Dialog {
 		gd_additionalParameter.horizontalIndent = 10;
 		additionalParameterTextBox.setLayoutData(gd_additionalParameter);
 
-		//addSelectionListenerToPartitionKeyButton(partitionKeyButton);
-
 		addModifyListenerToNoOfPartitionTextBox(noOfPartitionsTextBox);
 		addModifyListener(partitionKeyUpperBoundTextBox);
 		addModifyListener(partitionKeyLowerBoundTextBox);
@@ -275,8 +270,6 @@ public class InputAdditionalParametersDialog extends Dialog {
 		
 		return container;
 	}
-
-
 
 	private void setPropertyHelpText() {
 		if(ShowHidePropertyHelpHandler.getInstance() != null)
@@ -343,15 +336,10 @@ public class InputAdditionalParametersDialog extends Dialog {
 					
 					if(StringUtils.isBlank(partitionKeyLowerBoundTextBox.getText())){ partitionKeyLowerBoundControlDecoration.show();}
 					if(StringUtils.isBlank(partitionKeyUpperBoundTextBox.getText())){ partitionKeyUpperBoundControlDecoration.show();}
-					if(StringUtils.isEmpty((String) additionalParameterValue.get(Constants.DB_PARTITION_KEY)))
-					{
-						 //partitionKeyControlDecoration.show();
-					}
 					
 				}else{
 					partitionKeyLowerBoundControlDecoration.hide();
 					partitionKeyUpperBoundControlDecoration.hide();
-					//partitionKeyControlDecoration.hide();
 					partitionKeyButton.setEnabled(false);
 					partitionKeyLowerBoundTextBox.setEnabled(false);
 					partitionKeyUpperBoundTextBox.setEnabled(false);
@@ -369,7 +357,6 @@ public class InputAdditionalParametersDialog extends Dialog {
 					partitionKeyButton.setEnabled(false);
 					partitionKeyLowerBoundTextBox.setEnabled(false);
 					partitionKeyUpperBoundTextBox.setEnabled(false);
-					//partitionKeyControlDecoration.hide();
 				}
 			}
 
@@ -393,12 +380,6 @@ public class InputAdditionalParametersDialog extends Dialog {
 					&& StringUtils.isNotEmpty((String)additionalParameterValue.get(Constants.NUMBER_OF_PARTITIONS))) {
 				noOfPartitionsTextBox.setText(additionalParameterValue.get(Constants.NUMBER_OF_PARTITIONS).toString());
 				Utils.INSTANCE.addMouseMoveListener(noOfPartitionsTextBox, cursor);	
-				if (StringUtils.isNotBlank((String) additionalParameterValue.get(Constants.DB_PARTITION_KEY))) {
-					partitionKeyButton.setEnabled(true);
-					//partitionKeyControlDecoration.hide();
-				} else {
-					//partitionKeyControlDecoration.show();
-				}
 				if (additionalParameterValue.get(Constants.NOP_LOWER_BOUND) != null 
 						&& StringUtils.isNotEmpty((String) additionalParameterValue.get(Constants.NOP_LOWER_BOUND))) {
 					partitionKeyLowerBoundTextBox.setText(additionalParameterValue.get(Constants.NOP_LOWER_BOUND).toString());
@@ -417,7 +398,6 @@ public class InputAdditionalParametersDialog extends Dialog {
 					partitionKeyUpperBoundControlDecoration.show();
 				}
 			}else{
-				//partitionKeyControlDecoration.hide();
 				partitionKeyLowerBoundControlDecoration.hide();
 				partitionKeyUpperBoundControlDecoration.hide();
 			}
@@ -430,39 +410,6 @@ public class InputAdditionalParametersDialog extends Dialog {
 				Utils.INSTANCE.addMouseMoveListener(additionalParameterTextBox, cursor);
 			}
 		}
-
-	}
-
-	private void addSelectionListenerToPartitionKeyButton(Button partitionKeyButton) {
-		partitionKeyButton.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				if(StringUtils.isEmpty((String) additionalParameterValue.get(Constants.DB_PARTITION_KEY))){
-					//partitionKeyControlDecoration.show();
-				}else{
-					//partitionKeyControlDecoration.hide();
-					}
-				
-				FieldDialogForDBComponents fieldDialog = new FieldDialogForDBComponents(new Shell(),
-						propertyDialogButtonBar);
-				fieldDialog.setComponentName(Messages.PARTITION_KEYS_FOR_DB_COMPONENT);
-				fieldDialog.setSourceFieldsFromPropagatedSchema(schemaFields);
-				if (StringUtils.isNotBlank((String) additionalParameterValue.get(Constants.DB_PARTITION_KEY))) {
-					fieldDialog.setPropertyFromCommaSepratedString(
-							(String) additionalParameterValue.get(Constants.DB_PARTITION_KEY));
-				}
-				fieldDialog.open();
-				selectedPartitionKey = fieldDialog.getResultAsCommaSeprated();
-				
-				if (StringUtils.isEmpty(selectedPartitionKey) || StringUtils.isBlank(selectedPartitionKey)) {
-					//partitionKeyControlDecoration.show();
-					additionalParameterValue.put(partitionKeysLabel.getText(), selectedPartitionKey);
-				} else {
-					//partitionKeyControlDecoration.hide();
-					additionalParameterValue.put(partitionKeysLabel.getText(), selectedPartitionKey);
-				}
-			}
-		});
 
 	}
 
@@ -496,7 +443,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 		additionalParameterValue= new LinkedHashMap<>();
 		if (StringUtils.isNotBlank(noOfPartitionsTextBox.getText())) {
 			additionalParameterValue.put(Constants.NUMBER_OF_PARTITIONS, noOfPartitionsTextBox.getText());
-			additionalParameterValue.put(Constants.DB_PARTITION_KEY, selectedPartitionKey);
+			additionalParameterValue.put(Constants.DB_PARTITION_KEY, partitionKeyButton.getText());
 			additionalParameterValue.put(Constants.NOP_UPPER_BOUND, partitionKeyUpperBoundTextBox.getText());
 			additionalParameterValue.put(Constants.NOP_LOWER_BOUND, partitionKeyLowerBoundTextBox.getText());
 		}else{
@@ -510,7 +457,6 @@ public class InputAdditionalParametersDialog extends Dialog {
 		super.okPressed();
 	}
 	
-	
 	private String[] convertToArray(List<String> items) {
 		String[] stringItemsList = new String[items.size()];
 		int index = 0;
@@ -518,5 +464,5 @@ public class InputAdditionalParametersDialog extends Dialog {
 			stringItemsList[index++] = item;
 		}
 		return stringItemsList;
-	}
+		}
 	}

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/InputAdditionalParametersDialog.java
@@ -86,7 +86,6 @@ public class InputAdditionalParametersDialog extends Dialog {
 	private Text additionalParameterTextBox;
 	private ControlDecoration additionalParameterControlDecoration;
 	private Cursor cursor;
-	private boolean ShowHidePropertyHelpChecked;
 
 	/**
 	 * Create the dialog.
@@ -166,7 +165,7 @@ public class InputAdditionalParametersDialog extends Dialog {
 		partitionKeysLabel.setText(Messages.PARTITION_KEY);
 		
 		partitionKeyComboBox = new Combo(composite, SWT.DROP_DOWN);
-		partitionKeyComboBox.setItems(convertToArray(schemaFields));
+		partitionKeyComboBox.setItems(schemaFields.toArray(new String[schemaFields.size()]));
 		GridData gd_partitionKeyButton = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
 		partitionKeyComboBox.setVisibleItemCount(11);
 		partitionKeyComboBox.setEnabled(false);
@@ -175,10 +174,11 @@ public class InputAdditionalParametersDialog extends Dialog {
 		gd_partitionKeyButton.horizontalIndent = 10;
 		partitionKeyComboBox.setLayoutData(gd_partitionKeyButton);
 		
-		new AutoCompleteField(partitionKeyComboBox, new ComboContentAdapter(), convertToArray(schemaFields));
+		new AutoCompleteField(partitionKeyComboBox, new ComboContentAdapter(), schemaFields.toArray(new String[schemaFields.size()]));
 		
 		selectedPartitionKey = (String) additionalParameterValue.get(Constants.DB_PARTITION_KEY);
-		if(selectedPartitionKey != null){
+		
+		if(StringUtils.isNotBlank(selectedPartitionKey)){
 		partitionKeyComboBox.setText(selectedPartitionKey);
 		}
 		else{
@@ -275,10 +275,8 @@ public class InputAdditionalParametersDialog extends Dialog {
 	}
 
 	private void setPropertyHelpText() {
-		if(ShowHidePropertyHelpHandler.getInstance() != null)
-		ShowHidePropertyHelpChecked = ShowHidePropertyHelpHandler.getInstance().isShowHidePropertyHelpChecked();
-		
-		if(ShowHidePropertyHelpChecked){
+		if(ShowHidePropertyHelpHandler.getInstance() != null 
+				&& ShowHidePropertyHelpHandler.getInstance().isShowHidePropertyHelpChecked()){
 			noOfPartitionsLabel.setToolTipText(Messages.NUMBER_OF_PARTITIONS);
 			noOfPartitionsLabel.setCursor(new Cursor(noOfPartitionsLabel.getDisplay(), SWT.CURSOR_HELP));
 			
@@ -332,10 +330,10 @@ public class InputAdditionalParametersDialog extends Dialog {
 
 			@Override
 			public void modifyText(ModifyEvent event) {
+				if(StringUtils.isNotBlank(noOfPartitionsTextBox.getText())){
 				partitionKeyComboBox.setEnabled(true);
 				partitionKeyLowerBoundTextBox.setEnabled(true);
 				partitionKeyUpperBoundTextBox.setEnabled(true);
-				if (StringUtils.isNotBlank(noOfPartitionsTextBox.getText())) {
 					
 					if(StringUtils.isBlank(partitionKeyLowerBoundTextBox.getText())){ partitionKeyLowerBoundControlDecoration.show();}
 					if(StringUtils.isBlank(partitionKeyUpperBoundTextBox.getText())){ partitionKeyUpperBoundControlDecoration.show();}

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/LoadTypeConfigurationDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/LoadTypeConfigurationDialog.java
@@ -210,10 +210,8 @@ public class LoadTypeConfigurationDialog extends Dialog {
 	 * Set the Property Help Text
 	 */
 	private void setPropertyHelpText() {
-		if(ShowHidePropertyHelpHandler.getInstance() != null)
-		ShowHidePropertyHelpChecked = ShowHidePropertyHelpHandler.getInstance().isShowHidePropertyHelpChecked();
-		
-		if(ShowHidePropertyHelpChecked){
+		if(ShowHidePropertyHelpHandler.getInstance() != null 
+				&& ShowHidePropertyHelpHandler.getInstance().isShowHidePropertyHelpChecked()){
 			newTableRadioButton.setToolTipText(Messages.LOADCONFIG_NEWTABLE);
 			newTableRadioButton.setCursor(new Cursor(newTableRadioButton.getDisplay(), SWT.CURSOR_HELP));
 			

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/LoadTypeConfigurationDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/LoadTypeConfigurationDialog.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -37,6 +38,7 @@ import org.eclipse.swt.widgets.Widget;
 
 import hydrograph.ui.common.util.Constants;
 import hydrograph.ui.common.util.OSValidator;
+import hydrograph.ui.propertywindow.handlers.ShowHidePropertyHelpHandler;
 import hydrograph.ui.propertywindow.messages.Messages;
 import hydrograph.ui.propertywindow.propertydialog.PropertyDialogButtonBar;
 import hydrograph.ui.propertywindow.widgets.dialogs.FieldDialog;
@@ -58,6 +60,7 @@ public class LoadTypeConfigurationDialog extends Dialog {
 	private Button insertRadioButton;
 	private Button replaceRadioButton;
 	private Button[] radioButtons = new Button[]{newTableRadioButton, insertRadioButton, replaceRadioButton};
+	private boolean ShowHidePropertyHelpChecked;
 	
 	/**
 	 * Create the dialog.
@@ -199,9 +202,29 @@ public class LoadTypeConfigurationDialog extends Dialog {
 			//updateRadioButton.setEnabled(true);
 		}
 		
+		setPropertyHelpText();
 		return container;
 	}
-
+	
+	/**
+	 * Set the Property Help Text
+	 */
+	private void setPropertyHelpText() {
+		if(ShowHidePropertyHelpHandler.getInstance() != null)
+		ShowHidePropertyHelpChecked = ShowHidePropertyHelpHandler.getInstance().isShowHidePropertyHelpChecked();
+		
+		if(ShowHidePropertyHelpChecked){
+			newTableRadioButton.setToolTipText(Messages.LOADCONFIG_NEWTABLE);
+			newTableRadioButton.setCursor(new Cursor(newTableRadioButton.getDisplay(), SWT.CURSOR_HELP));
+			
+			insertRadioButton.setToolTipText(Messages.LOADCONFIG_INSERT);
+			insertRadioButton.setCursor(new Cursor(insertRadioButton.getDisplay(), SWT.CURSOR_HELP));
+			
+			replaceRadioButton.setToolTipText(Messages.LOADCONFIG_REPLACE);
+			replaceRadioButton.setCursor(new Cursor(replaceRadioButton.getDisplay(), SWT.CURSOR_HELP));
+		}
+	}
+	
 	/**
 	 * The Function will call to disable the widgets
 	 * @param textbox1

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/OutputAdditionalParametersDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/OutputAdditionalParametersDialog.java
@@ -119,7 +119,7 @@ public class OutputAdditionalParametersDialog extends Dialog {
 
 		chunkSize = new Label(composite, SWT.NONE);
 		GridData gd_chunkSize = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-		gd_chunkSize.widthHint = 218;
+		gd_chunkSize.widthHint = 150;
 		chunkSize.setLayoutData(gd_chunkSize);
 		chunkSize.setText(Messages.DB_CHUNK_SIZE);
 
@@ -134,7 +134,7 @@ public class OutputAdditionalParametersDialog extends Dialog {
 
 		additionalDBParametersLabel = new Label(composite, SWT.NONE);
 		GridData gd_additionalDBParametersLabel = new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1);
-		gd_additionalDBParametersLabel.widthHint = 218;
+		gd_additionalDBParametersLabel.widthHint = 150;
 		additionalDBParametersLabel.setLayoutData(gd_additionalDBParametersLabel);
 		additionalDBParametersLabel.setText(Messages.ADDITIONAL_DB_PARAMETERS);
 

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/OutputAdditionalParametersDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/OutputAdditionalParametersDialog.java
@@ -20,10 +20,13 @@ import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ControlAdapter;
+import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -33,6 +36,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
 import hydrograph.ui.common.util.Constants;
+import hydrograph.ui.propertywindow.handlers.ShowHidePropertyHelpHandler;
 import hydrograph.ui.propertywindow.messages.Messages;
 import hydrograph.ui.propertywindow.propertydialog.PropertyDialogButtonBar;
 import hydrograph.ui.propertywindow.utils.Utils;
@@ -60,6 +64,7 @@ public class OutputAdditionalParametersDialog extends Dialog {
 	private Text additionalParameterTextBox;
 	private ControlDecoration additionalParameterControlDecoration;
 	private Cursor cursor;
+	private boolean ShowHidePropertyHelpChecked;
 
 	/**
 	 * Create the dialog.
@@ -73,7 +78,7 @@ public class OutputAdditionalParametersDialog extends Dialog {
 	public OutputAdditionalParametersDialog(Shell parentShell, String windowTitle,
 			PropertyDialogButtonBar propertyDialogButtonBar, Map<String, Object> initialMap, Cursor cursor) {
 		super(parentShell);
-		setShellStyle(SWT.CLOSE | SWT.TITLE | SWT.WRAP | SWT.APPLICATION_MODAL);
+		setShellStyle(SWT.CLOSE | SWT.TITLE | SWT.WRAP | SWT.APPLICATION_MODAL | SWT.RESIZE);
 		if (StringUtils.isNotBlank(windowTitle))
 			windowLabel = windowTitle;
 		else
@@ -93,6 +98,21 @@ public class OutputAdditionalParametersDialog extends Dialog {
 		Composite container = (Composite) super.createDialogArea(parent);
 		container.setLayout(new GridLayout(1, false));
 		container.getShell().setText(windowLabel);
+		
+		int CONST_HEIGHT = 181;
+				
+				Shell shell = container.getShell();
+				
+				shell.addControlListener(new ControlAdapter() {
+		            @Override
+		            public void controlResized(ControlEvent e) {
+		                Rectangle rect = shell.getBounds();
+		                if(rect.width != CONST_HEIGHT) {
+		                    shell.setBounds(rect.x, rect.y, rect.width, CONST_HEIGHT);
+		                }
+		            }
+		        });
+		
 		Composite composite = new Composite(container, SWT.NONE);
 		composite.setLayout(new GridLayout(2, false));
 		composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
@@ -134,8 +154,25 @@ public class OutputAdditionalParametersDialog extends Dialog {
 		addListenerToAdditionalParameter(additionalParameterTextBox);
 
 		addOutputAdditionalParameterValues();
+		
+		getShell().setMinimumSize(getInitialSize());
+		
+		setPropertyHelpText();
 
 		return container;
+	}
+
+	private void setPropertyHelpText() {
+		if(ShowHidePropertyHelpHandler.getInstance() != null)
+			ShowHidePropertyHelpChecked = ShowHidePropertyHelpHandler.getInstance().isShowHidePropertyHelpChecked();
+			
+			if(ShowHidePropertyHelpChecked){
+				chunkSize.setToolTipText(Messages.CHUNK_SIZE);
+				chunkSize.setCursor(new Cursor(chunkSize.getDisplay(), SWT.CURSOR_HELP));
+				
+				additionalDBParametersLabel.setToolTipText(Messages.ADDITIONAL_DB_PARAMETER);
+				additionalDBParametersLabel.setCursor(new Cursor(additionalDBParametersLabel.getDisplay(), SWT.CURSOR_HELP));
+			}
 	}
 
 	private void addModifyListener(Text text){

--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/OutputAdditionalParametersDialog.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/customwidgets/databasecomponents/OutputAdditionalParametersDialog.java
@@ -163,10 +163,8 @@ public class OutputAdditionalParametersDialog extends Dialog {
 	}
 
 	private void setPropertyHelpText() {
-		if(ShowHidePropertyHelpHandler.getInstance() != null)
-			ShowHidePropertyHelpChecked = ShowHidePropertyHelpHandler.getInstance().isShowHidePropertyHelpChecked();
-			
-			if(ShowHidePropertyHelpChecked){
+		if(ShowHidePropertyHelpHandler.getInstance() != null 
+				&& ShowHidePropertyHelpHandler.getInstance().isShowHidePropertyHelpChecked()){
 				chunkSize.setToolTipText(Messages.CHUNK_SIZE);
 				chunkSize.setCursor(new Cursor(chunkSize.getDisplay(), SWT.CURSOR_HELP));
 				


### PR DESCRIPTION
Fixing following bugs:
1 Error bubble is getting displayed when user provides value of Additional DB parameters with space.
2.(a). The upper bound and lower bound text boxes’ position should be interchanged.
   (b). Window should be resizable and the text boxes should expand / resize as per the window.
   (c). Reduce unnecessary space between label and text box and the space above buttons.
3. Implement dropdown which display default 10 fields with scrollbar and with auto suggestion
should be present for Partition Keys field instead of Partition Keys window.
4. Adding PropertyHelpText for additionalParamterDialog of DB component.