### PR TITLE
Changed Flow Execution Logic

### DIFF
--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/flow/FlowBuilder.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/flow/FlowBuilder.scala
@@ -1,15 +1,15 @@
-/*******************************************************************************
- * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+/** *****************************************************************************
+  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  * http://www.apache.org/licenses/LICENSE-2.0
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  * ******************************************************************************/
 package hydrograph.engine.spark.flow
 
 import hydrograph.engine.jaxb.commontypes._
@@ -18,12 +18,13 @@ import hydrograph.engine.spark.components.adapter.ExecutionTrackingAdapter
 import hydrograph.engine.spark.components.adapter.base.{RunProgramAdapterBase, _}
 import hydrograph.engine.spark.components.base.{ComponentParameterBuilder, SparkFlow}
 import hydrograph.engine.spark.components.platform.BaseComponentParams
-import hydrograph.engine.spark.execution.tracking.PartitionStageAccumulator
+import hydrograph.engine.spark.executiontracking.plugin.HydrographCommandListener
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.storage.StorageLevel
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+
 /**
   * The Class FlowBuilder.
   *
@@ -31,81 +32,87 @@ import scala.collection.mutable
   *
   */
 
-class FlowBuilder(runtimeContext: RuntimeContext) {
+class FlowBuilder(runtimeContext: RuntimeContext, hydrographListener: HydrographCommandListener) {
 
 
-  def buildFlow(): mutable.LinkedHashSet[SparkFlow] ={
-    val flow=new mutable.LinkedHashSet[SparkFlow]()
-    for(batch<- runtimeContext.traversal.getFlowsNumber.asScala){
-     flow ++= createAndConnect(batch)
+  def buildAndExecuteFlows(): Unit = {
+    val flow = new mutable.LinkedHashSet[SparkFlow]()
+    for (batch <- runtimeContext.traversal.getFlowsNumber.asScala) {
+      createAndConnect(batch).foreach( flow => {
+        try {
+          hydrographListener.start(flow)
+          flow.execute()
+          hydrographListener.end(flow)
+        } catch {
+          case e: Exception => hydrographListener.failComponentsOfFlow(flow)
+            throw e
+        }
+      })
     }
-
-    flow
   }
 
 
-  def createAndConnect(batch:String): mutable.LinkedHashSet[SparkFlow] = {
-    val flow=new mutable.LinkedHashSet[SparkFlow]()
-    val outLinkMap = new mutable.HashMap[String, Map[String,DataFrame]]()
+  def createAndConnect(batch: String): mutable.LinkedHashSet[SparkFlow] = {
+    val flow = new mutable.LinkedHashSet[SparkFlow]()
+    val outLinkMap = new mutable.HashMap[String, Map[String, DataFrame]]()
 
 
     for (compID <- runtimeContext.traversal.getOrderedComponentsList(batch).asScala) {
 
       var baseComponentParams: BaseComponentParams = null;
-      val adapterBase:AdapterBase = runtimeContext.adapterFactory.getAdapterMap().get(compID).get
-
+      val adapterBase: AdapterBase = runtimeContext.adapterFactory.getAdapterMap().get(compID).get
 
 
       if (adapterBase.isInstanceOf[InputAdatperBase]) {
-        baseComponentParams = ComponentParameterBuilder(compID, runtimeContext, outLinkMap,new BaseComponentParams())
+        baseComponentParams = ComponentParameterBuilder(compID, runtimeContext, outLinkMap, new BaseComponentParams())
           .setSparkSession(runtimeContext.sparkSession).build()
 
         adapterBase.createComponent(baseComponentParams)
-        val inputDataFrame= adapterBase.asInstanceOf[InputAdatperBase].getComponent().createComponent()
-        setCacheLevel(extractRuntimeProperties(compID,runtimeContext.hydrographJob.getJAXBObject),inputDataFrame)
-        outLinkMap +=(compID -> inputDataFrame)
+        val inputDataFrame = adapterBase.asInstanceOf[InputAdatperBase].getComponent().createComponent()
+        setCacheLevel(extractRuntimeProperties(compID, runtimeContext.hydrographJob.getJAXBObject), inputDataFrame)
+        outLinkMap += (compID -> inputDataFrame)
       }
-        else if(adapterBase.isInstanceOf[ExecutionTrackingAdapter]){
+      else if (adapterBase.isInstanceOf[ExecutionTrackingAdapter]) {
 
-        baseComponentParams = ComponentParameterBuilder(compID, runtimeContext, outLinkMap,new BaseComponentParams())
+        baseComponentParams = ComponentParameterBuilder(compID, runtimeContext, outLinkMap, new BaseComponentParams())
           .setInputDataFrame().setSparkSession(runtimeContext.sparkSession).setInputDataFrameWithCompID().setInputSchemaFieldsWithCompID()
           .setOutputSchemaFields().setInputSchemaFields().build()
 
 
         adapterBase.createComponent(baseComponentParams)
-        val opDataFrame= adapterBase.asInstanceOf[OperationAdatperBase].getComponent().createComponent()
-        outLinkMap +=(compID -> opDataFrame)
+        val opDataFrame = adapterBase.asInstanceOf[OperationAdatperBase].getComponent().createComponent()
+        outLinkMap += (compID -> opDataFrame)
 
 
       }
 
       else if (adapterBase.isInstanceOf[OperationAdatperBase]) {
-        baseComponentParams = ComponentParameterBuilder(compID, runtimeContext, outLinkMap,new BaseComponentParams())
+        baseComponentParams = ComponentParameterBuilder(compID, runtimeContext, outLinkMap, new BaseComponentParams())
           .setInputDataFrame().setSparkSession(runtimeContext.sparkSession).setInputDataFrameWithCompID().setInputSchemaFieldsWithCompID()
           .setOutputSchemaFieldsForOperation().setInputSchemaFields().build()
 
         adapterBase.createComponent(baseComponentParams)
-        val opDataFrame= adapterBase.asInstanceOf[OperationAdatperBase].getComponent().createComponent()
-        setCacheLevel(extractRuntimeProperties(compID,runtimeContext.hydrographJob.getJAXBObject),opDataFrame)
-        outLinkMap +=(compID -> opDataFrame)
+        val opDataFrame = adapterBase.asInstanceOf[OperationAdatperBase].getComponent().createComponent()
+        setCacheLevel(extractRuntimeProperties(compID, runtimeContext.hydrographJob.getJAXBObject), opDataFrame)
+        outLinkMap += (compID -> opDataFrame)
 
       }
       else if (adapterBase.isInstanceOf[StraightPullAdatperBase]) {
-        baseComponentParams = ComponentParameterBuilder(compID, runtimeContext, outLinkMap,new BaseComponentParams())
+        baseComponentParams = ComponentParameterBuilder(compID, runtimeContext, outLinkMap, new BaseComponentParams())
           .setInputDataFrame().setOutputSchemaFields().setInputSchemaFields().build()
 
         adapterBase.createComponent(baseComponentParams)
-        val opDataFrame= adapterBase.asInstanceOf[StraightPullAdatperBase].getComponent().createComponent()
-        setCacheLevel(extractRuntimeProperties(compID,runtimeContext.hydrographJob.getJAXBObject),opDataFrame)
+        val opDataFrame = adapterBase.asInstanceOf[StraightPullAdatperBase].getComponent().createComponent()
+        setCacheLevel(extractRuntimeProperties(compID, runtimeContext.hydrographJob.getJAXBObject), opDataFrame)
 
-        outLinkMap +=(compID -> opDataFrame)
+        outLinkMap += (compID -> opDataFrame)
       }
       else if (adapterBase.isInstanceOf[OutputAdatperBase]) {
-        baseComponentParams = ComponentParameterBuilder(compID, runtimeContext, outLinkMap,new BaseComponentParams())
-            .setSparkSession(runtimeContext.sparkSession).setInputDataFrame().build()
+        baseComponentParams = ComponentParameterBuilder(compID, runtimeContext, outLinkMap, new BaseComponentParams())
+          .setSparkSession(runtimeContext.sparkSession).setInputDataFrame().build()
 
         adapterBase.createComponent(baseComponentParams)
-      flow += adapterBase.asInstanceOf[OutputAdatperBase].getComponent()
+        flow += adapterBase.asInstanceOf[OutputAdatperBase].getComponent()
         adapterBase.asInstanceOf[OutputAdatperBase].getComponent().setSparkFlowName(compID)
 
       }
@@ -119,13 +126,16 @@ class FlowBuilder(runtimeContext: RuntimeContext) {
 
     }
 
-flow
+    flow
   }
 
-  private def extractRuntimeProperties(compId:String,graph: Graph): TypeProperties ={
-    val jaxbObject=graph.getInputsOrOutputsOrStraightPulls.asScala
+  private def extractRuntimeProperties(compId: String, graph: Graph): TypeProperties
 
-    jaxbObject.filter(c=>c.getId.equals(compId)).head match {
+  =
+  {
+    val jaxbObject = graph.getInputsOrOutputsOrStraightPulls.asScala
+
+    jaxbObject.filter(c => c.getId.equals(compId)).head match {
       case op: TypeInputComponent =>
         op.asInstanceOf[TypeInputComponent].getRuntimeProperties
       case op: TypeOutputComponent =>
@@ -138,11 +148,14 @@ flow
     }
   }
 
-  private def setCacheLevel(typeProperty: TypeProperties,dataFrameMap:Map[String,DataFrame]): Unit ={
-    val splitter=":"
-    if(typeProperty!= null && typeProperty.getProperty!=null){
-      typeProperty.getProperty.asScala.filter(tp=> tp.getName.equalsIgnoreCase("cache")).foreach(tp=>{
-        if(tp.getValue.contains(splitter)) {
+  private def setCacheLevel(typeProperty: TypeProperties, dataFrameMap: Map[String, DataFrame]): Unit
+
+  =
+  {
+    val splitter = ":"
+    if (typeProperty != null && typeProperty.getProperty != null) {
+      typeProperty.getProperty.asScala.filter(tp => tp.getName.equalsIgnoreCase("cache")).foreach(tp => {
+        if (tp.getValue.contains(splitter)) {
           val storageType = tp.getValue.trim.substring(tp.getValue.trim.lastIndexOf(splitter) + 1, tp.getValue.trim.length)
           val outSocketId = tp.getValue.trim.substring(0, tp.getValue.trim.lastIndexOf(splitter))
 
@@ -160,8 +173,8 @@ flow
           }
 
         }
-        else{
-          throw new RuntimeException("Cache Property value should be in proper format eg: outSocketID : One of \"disk,memory,memory_and_disk\", But user provides: "+ tp.getValue)
+        else {
+          throw new RuntimeException("Cache Property value should be in proper format eg: outSocketID : One of \"disk,memory,memory_and_disk\", But user provides: " + tp.getValue)
         }
       })
     }
@@ -169,7 +182,7 @@ flow
 }
 
 object FlowBuilder {
-  def apply(runtimeContext: RuntimeContext): FlowBuilder = {
-    new FlowBuilder(runtimeContext)
+  def apply(runtimeContext: RuntimeContext, hydrographListener: HydrographCommandListener): FlowBuilder = {
+    new FlowBuilder(runtimeContext, hydrographListener)
   }
 }


### PR DESCRIPTION
Earlier flows were build for all batches in FlowBuilder and later executed batch-wise.
In this commit, we changed this logic to build flow for a single batch and execute it right there and repeat the process for next batch.