### PR TITLE
Issue fix: unionAll component

### DIFF
--- a/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/utility/SubjobUtility.java
+++ b/hydrograph.ui/hydrograph.ui.propertywindow/src/main/java/hydrograph/ui/propertywindow/widgets/utility/SubjobUtility.java
@@ -180,11 +180,9 @@ public static final SubjobUtility INSTANCE= new SubjobUtility();
 	
 	private boolean isSameSchema(Schema previousSchema, Schema currentComponentSchema) {
 		if(	(previousSchema!=null && currentComponentSchema!=null)
-			&&  (previousSchema.getIsExternal() == currentComponentSchema.getIsExternal())
-			&& (StringUtils.equals(previousSchema.getExternalSchemaPath(), currentComponentSchema.getExternalSchemaPath()))
 			&& (previousSchema.getGridRow()!=null && currentComponentSchema.getGridRow()!=null)
 			&& (previousSchema.getGridRow().size()==currentComponentSchema.getGridRow().size())){
-			for(int index=0;index<previousSchema.getGridRow().size();index++){
+			for(int index = 0; index <previousSchema.getGridRow().size(); index++){
 				if(!SchemaPropagationHelper.INSTANCE.isGridRowEqual(previousSchema.getGridRow().get(index),
 						currentComponentSchema.getGridRow().get(index))){
 					return false;


### PR DESCRIPTION
Issue description :
One Input component is using “External Schema” whereas another one has the same schema used as “Internal Schema" , and when try to propagate the schema in Union All Component , it throws  error like:
'Inputs Schema are not in Sync'.
