### PR TITLE
Enable use of prepare() in Filter custom class

### DIFF
--- a/hydrograph.engine/hydrograph.engine.command-line/testData/XMLFiles/FilterExampleWithPrepare.xml
+++ b/hydrograph.engine/hydrograph.engine.command-line/testData/XMLFiles/FilterExampleWithPrepare.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License
+ -->
+
+<p:graph name="FilterExample" xmlns:p="hydrograph/engine/jaxb/main"
+		 xmlns:it="hydrograph/engine/jaxb/inputtypes" xmlns:ot="hydrograph/engine/jaxb/outputtypes"
+		 xmlns:op="hydrograph/engine/jaxb/operationstypes"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="hydrograph/engine/jaxb/main ../../../hydrograph.engine.core/src/main/resources/newxmlschema/main/main.xsd  ">
+
+	<inputs id="input1" batch="0" xsi:type="it:textFileDelimited">
+		<outSocket id="out0" type="out">
+			<schema name="klk">
+				<field name="name" type="java.lang.String"  />
+				<field name="Gift" type="java.lang.String"  />
+				<field name="DOB" type="java.util.Date" format="yyyy-MM-dd"  />
+				<field name="Choice" type="java.lang.String"  />
+			</schema>
+		</outSocket>
+		<path uri="testData/Input/FilterFile.txt" />
+		<delimiter value="," />
+		<hasHeader value="false" />
+	</inputs>
+
+	<operations id="trans" batch="0" xsi:type="op:filter">
+		<inSocket fromComponentId="input1" fromSocketId="out0" id="in0" />
+		<operation id="operation1" class="hydrograph.engine.transformation.userfunctions.filter.FilterWithPrepareFunction">
+			<inputFields>
+				<field name="Choice" inSocketId="in0" />
+			</inputFields>
+			<properties>
+			<property name="Filter" value="@{FilterString}" />
+		</properties>
+		</operation>
+		<outSocket id="out1" type="out">
+			<copyOfInsocket inSocketId="in0" />
+		</outSocket>
+		<outSocket id="unused1" type="unused">
+			<copyOfInsocket inSocketId="in0" />
+		</outSocket>
+	</operations>
+
+	<outputs id="output1" batch="0" xsi:type="ot:textFileDelimited">
+		<inSocket fromComponentId="trans" fromSocketId="out1" id="in0">
+			<schema name="Detail">
+				<field name="name" type="java.lang.String"  />
+				<field name="Gift" type="java.lang.String" />
+				<field name="DOB" type="java.util.Date" format="yyyy-MM-dd"/>
+				<field name="Choice" type="java.lang.String"/>
+			</schema>
+		</inSocket>
+		<path uri="testData/Output/Filter/Output" />
+		<delimiter value="," />
+		<hasHeader value="false" />
+		<charset value="ISO-8859-1" />
+	</outputs>
+
+	<outputs id="unusedOutput" batch="0" xsi:type="ot:textFileDelimited">
+		<inSocket fromComponentId="trans" fromSocketId="unused1" id="in0"
+			fromSocketType="unused">
+			<schema name="Detail">
+				<field name="name" type="java.lang.String"  />
+				<field name="Gift" type="java.lang.String"  />
+				<field name="DOB" type="java.util.Date" format="yyyy-MM-dd"/>
+				<field name="Choice" type="java.lang.String"  />
+			</schema>
+		</inSocket>
+		<path uri="testData/Output/Filter/UnusedOutput" />
+		<delimiter value="," />
+		<hasHeader value="false" />
+		<charset value="ISO-8859-1" />
+	</outputs>
+</p:graph>

--- a/hydrograph.engine/hydrograph.engine.expression/src/main/java/hydrograph/engine/expression/api/ValidationAPI.java
+++ b/hydrograph.engine/hydrograph.engine.expression/src/main/java/hydrograph/engine/expression/api/ValidationAPI.java
@@ -284,7 +284,9 @@ public class ValidationAPI implements Serializable {
 		if(className.equalsIgnoreCase("string"))
 			return String.class;
 		else if(className.equalsIgnoreCase("Integer"))
-				return Integer.class;
+			return Integer.class;
+		else if(className.equalsIgnoreCase("Short"))
+			return Short.class;
 		else if(className.equalsIgnoreCase("Long"))
 			return Long.class;
 		else if(className.equalsIgnoreCase("Boolean"))
@@ -299,7 +301,7 @@ public class ValidationAPI implements Serializable {
 			return Object.class;
 		else if(className.contains("decimal") || className.contains("BigDecimal") )
 			return BigDecimal.class;
-		return String.class;
+		return Object.class;
 
 	}
 

--- a/hydrograph.engine/hydrograph.engine.expression/src/main/java/hydrograph/engine/expression/userfunctions/TransformForExpression.java
+++ b/hydrograph.engine/hydrograph.engine.expression/src/main/java/hydrograph/engine/expression/userfunctions/TransformForExpression.java
@@ -61,8 +61,12 @@ public class TransformForExpression implements TransformBase {
 			tuples[i] = inputRow.getField(i);
 		}
 		try {
-			outputRow.setField(0,
-					(Comparable) validationAPI.exec(tuples));
+			Object output = validationAPI.exec(tuples);
+			if(output instanceof java.util.Date) {
+				outputRow.setDate(0, (Comparable) output);
+			}else {
+				outputRow.setField(0, (Comparable) output);
+			}
 		} catch (Exception e) {
 			throw new RuntimeException("Tranform Expression: "
 					+ validationAPI.getValidExpression()

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/FilterComponentWithMapPartitions.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/FilterComponentWithMapPartitions.scala
@@ -1,0 +1,96 @@
+/** *****************************************************************************
+  * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  * http://www.apache.org/licenses/LICENSE-2.0
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  * ******************************************************************************/
+package hydrograph.engine.spark.components
+
+import hydrograph.engine.core.component.entity.FilterEntity
+import hydrograph.engine.expression.userfunctions.FilterForExpression
+import hydrograph.engine.spark.components.base.OperationComponentBase
+import hydrograph.engine.spark.components.handler.OperationHelper
+import hydrograph.engine.spark.components.platform.BaseComponentParams
+import hydrograph.engine.spark.components.utils.{ReusableRowHelper, RowHelper}
+import hydrograph.engine.transformation.userfunctions.base.FilterBase
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, Row}
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+/**
+  * The Class FilterComponentWithMapPartitions.
+  *
+  * @author Bitwise
+  *
+  */
+class FilterComponentWithMapPartitions(filterEntity: FilterEntity, componentsParams: BaseComponentParams) extends
+  OperationComponentBase with OperationHelper[FilterBase] with Serializable {
+  val LOG = LoggerFactory.getLogger(classOf[FilterComponent])
+
+  override def createComponent(): Map[String, DataFrame] = {
+
+    LOG.info("Filter Component Called with input Schema [in the form of(Column_name,DataType,IsNullable)]: {}", componentsParams.getDataFrame().schema)
+    val inputSchema: StructType = componentsParams.getDataFrame().schema
+    val outputSchema = inputSchema
+    val operationalSchema =  RowEncoder(componentsParams.getDataFrame().schema)
+
+    var map: Map[String, DataFrame] = Map()
+
+    val filterSparkOperations = initializeOperationList[FilterForExpression](filterEntity.getOperationsList,
+      inputSchema, outputSchema).head
+    val filterClass = filterSparkOperations.baseClassInstance
+
+    val opProps = filterSparkOperations.operationEntity.getOperationProperties
+
+    LOG.info("Operation Properties: " + opProps)
+    if (opProps != null) FilterBase.properties.putAll(opProps)
+
+
+
+    filterEntity.getOutSocketList.asScala.foreach { outSocket =>
+      LOG.info("Creating filter Component for '" + filterEntity.getComponentId + "' for socket: '"
+        + outSocket.getSocketId + "' of type: '" + outSocket.getSocketType + "'")
+
+      val df = componentsParams.getDataFrame.mapPartitions(itr => {
+
+        filterClass match {
+          case expression: FilterForExpression => expression.setValidationAPI(filterSparkOperations.validatioinAPI)
+            try {
+              expression.callPrepare(filterSparkOperations.fieldName, filterSparkOperations.fieldType)
+            } catch {
+              case e: Exception =>
+                LOG.error("Exception in callPrepare method of: " + expression.getClass + " and message is " + e.getMessage, e)
+                throw new InitializationException("Exception in initialization of: " + expression.getClass + " and message is " + e.getMessage, e)
+            }
+          case f: FilterBase => f.prepare(filterSparkOperations.operationEntity.getOperationProperties, filterSparkOperations.operationEntity.getOperationInputFields)
+          case _ =>
+        }
+
+        itr.filter( row =>{
+
+
+          if (outSocket.getSocketType.equalsIgnoreCase("out")) {
+            !filterClass.isRemove(filterSparkOperations.inputRow.setRow(row))
+          }
+          else {
+            filterClass.isRemove(filterSparkOperations.inputRow.setRow(row))
+          }
+
+        })
+
+      })(operationalSchema)
+
+      map += (outSocket.getSocketId -> df)
+
+    }
+    map
+  }
+}

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/FilterComponentWithUDF.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/FilterComponentWithUDF.scala
@@ -54,6 +54,7 @@ class FilterComponentWithUDF(filterEntity: FilterEntity, componentsParams: BaseC
       filterClass match {
         case expression: FilterForExpression => expression.setValidationAPI(filterSparkOperations.validatioinAPI)
           expression.callPrepare(filterSparkOperations.fieldName, filterSparkOperations.fieldType)
+        case f: FilterBase => f.prepare(filterSparkOperations.operationEntity.getOperationProperties, filterSparkOperations.operationEntity.getOperationInputFields)
         case _ =>
       }
     } catch {

--- a/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/adapter/FilterAdapterWithMapPartitions.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/main/scala/hydrograph/engine/spark/components/adapter/FilterAdapterWithMapPartitions.scala
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package hydrograph.engine.spark.components.adapter
+
+import hydrograph.engine.core.component.generator.FilterEntityGenerator
+import hydrograph.engine.jaxb.commontypes.TypeBaseComponent
+import hydrograph.engine.spark.components.FilterComponentWithMapPartitions
+import hydrograph.engine.spark.components.adapter.base.OperationAdatperBase
+import hydrograph.engine.spark.components.base.OperationComponentBase
+import hydrograph.engine.spark.components.platform.BaseComponentParams
+
+/**
+  * The Class FilterAdapter.
+  *
+  * @author Bitwise
+  *
+  */
+class FilterAdapterWithMapPartitions(typeBaseComponent: TypeBaseComponent) extends OperationAdatperBase {
+
+  var filter: FilterEntityGenerator = null;
+  var sparkFilterComponent: FilterComponentWithMapPartitions = null;
+
+  override def createGenerator(): Unit = {
+    filter = new FilterEntityGenerator(typeBaseComponent)
+  }
+
+  override def createComponent(baseComponentParams: BaseComponentParams): Unit = {
+    sparkFilterComponent = new FilterComponentWithMapPartitions(filter.getEntity, baseComponentParams)
+  }
+
+  override def getComponent(): OperationComponentBase = sparkFilterComponent
+}

--- a/hydrograph.engine/hydrograph.engine.spark/src/test/scala/hydrograph/engine/spark/components/FilterComponentWithMapPartitionsTest.scala
+++ b/hydrograph.engine/hydrograph.engine.spark/src/test/scala/hydrograph/engine/spark/components/FilterComponentWithMapPartitionsTest.scala
@@ -1,0 +1,260 @@
+/*******************************************************************************
+ * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package hydrograph.engine.spark.components
+
+import java.util
+import java.util.Properties
+
+import hydrograph.engine.core.component.entity.FilterEntity
+import hydrograph.engine.core.component.entity.elements.{Operation, OutSocket, SchemaField}
+import hydrograph.engine.spark.components.platform.BaseComponentParams
+import hydrograph.engine.testing.wrapper.{Bucket, DataBuilder, Fields}
+import junit.framework.Assert
+import org.apache.spark.sql.Row
+import org.hamcrest.CoreMatchers._
+import org.junit.Assert._
+import org.junit.Test
+
+/**
+  * The Class FilterComponentWithMapPartitionsTest.
+  *
+  * @author Bitwise
+  *
+  */
+class FilterComponentWithMapPartitionsTest {
+
+  @Test
+  def FilterWithOnlyOutPort(): Unit = {
+    val df1 = new DataBuilder(Fields(List("col1", "col2", "col3", "col4")).applyTypes(List(classOf[Integer],
+      classOf[String], classOf[String], classOf[String])))
+      .addData(List(1, "C2R1", "C3Rx", "C4R1"))
+      .addData(List(2, "C2R2", "C3Rx", "C4R2"))
+      .addData(List(3, "C2R3", "C3Rx", "C4R3"))
+      .addData(List(3, "C2R3", "C3Rx", "C4R3"))
+      .build()
+
+    val operationProperties: Properties = new Properties
+    operationProperties.put("Filter", "filter")
+
+
+    val operationInputFields: Array[String] = Array("col2")
+    val operationClass: String = "hydrograph.engine.transformation.userfunctions.filter.Filter"
+
+    val filterEntity: FilterEntity = new FilterEntity
+    filterEntity.setComponentId("filterTest")
+
+    val operation: Operation = new Operation
+    operation.setOperationClass(operationClass)
+    operation.setOperationInputFields(operationInputFields)
+    operation.setOperationProperties(operationProperties)
+
+    filterEntity.setOperation(operation)
+
+    val outSocketList = new util.ArrayList[OutSocket]
+    outSocketList.add(new OutSocket("out0", "out"))
+    filterEntity.setOutSocketList(outSocketList)
+
+    val cp = new BaseComponentParams
+    cp.addinputDataFrame(df1)
+    cp.addSchemaFields(Array(new SchemaField("col1", "java.lang.Integer"), new SchemaField("col2", "java.lang.String"), new SchemaField("col3", "java.lang.String"), new SchemaField("col4", "java.lang.String")))
+
+    val filterDF = new FilterComponentWithMapPartitions(filterEntity, cp).createComponent()
+
+    val rows = Bucket(Fields(List("col1", "col2", "col3", "col4")), filterDF.get("out0").get).result()
+    Assert.assertEquals(2, rows.size)
+  }
+
+  @Test
+  def TestFilterComponentWorking(): Unit = {
+    val df1 = new DataBuilder(Fields(List("col1", "col2", "col3")).applyTypes(List(classOf[String], classOf[String], classOf[String])))
+      .addData(List("C1R1", "C2R1", "C3R1"))
+      .addData(List("C1R1", "C2R2", "C3R2"))
+      .build()
+
+
+    val operationInputFields: Array[String] = Array("col1")
+    val operationClass: String = "hydrograph.engine.transformation.userfunctions.filter.CustomFilterOperation"
+
+    val filterEntity: FilterEntity = new FilterEntity
+    filterEntity.setComponentId("filterTest")
+
+    val operation: Operation = new Operation
+    operation.setOperationClass(operationClass)
+    operation.setOperationInputFields(operationInputFields)
+
+    filterEntity.setOperation(operation)
+
+    val outSocketList = new util.ArrayList[OutSocket]
+    outSocketList.add(new OutSocket("out0", "out"))
+    filterEntity.setOutSocketList(outSocketList)
+
+    val cp = new BaseComponentParams
+    cp.addinputDataFrame(df1)
+    cp.addSchemaFields(Array(new SchemaField("col1", "java.lang.String"), new SchemaField("col2", "java.lang.String"), new SchemaField("col3", "java.lang.String"), new SchemaField("col3", "java.lang.String")))
+
+    val filterDF = new FilterComponentWithMapPartitions(filterEntity, cp).createComponent()
+    val rows = Bucket(Fields(List("col1", "col2", "col3")), filterDF.get("out0").get).result()
+    assertThat(rows.size, is(2))
+  }
+
+  @Test
+  def FilterWithOnlyOutPortOptionalType(): Unit = {
+    val df1 = new DataBuilder(Fields(List("col1", "col2", "col3")).applyTypes(List(classOf[String], classOf[String], classOf[String])))
+      .addData(List("C1R1", "C2R1", "C3R1"))
+      .addData(List("C1R1", "C2R2", "C3R2"))
+      .build()
+
+    val operationProperties: Properties = new Properties
+    operationProperties.put("Filter", "filter")
+    val operationInputFields: Array[String] = Array("col1")
+    val operationClass: String = "hydrograph.engine.transformation.userfunctions.filter.CustomFilterOperation"
+    val filterEntity: FilterEntity = new FilterEntity
+    filterEntity.setComponentId("filterTest")
+    val operation: Operation = new Operation
+    operation.setOperationClass(operationClass)
+    operation.setOperationInputFields(operationInputFields)
+    operation.setOperationProperties(operationProperties)
+    filterEntity.setOperation(operation)
+    val outSocketList: util.List[OutSocket] = new util.ArrayList[OutSocket]
+    outSocketList.add(new OutSocket("out0", "out"))
+    filterEntity.setOutSocketList(outSocketList)
+
+    val cp = new BaseComponentParams
+    cp.addinputDataFrame(df1)
+    cp.addSchemaFields(Array(new SchemaField("col1", "java.lang.String"), new SchemaField("col2", "java.lang.String"), new SchemaField("col3", "java.lang.String"), new SchemaField("col3", "java.lang.String")))
+
+    val filterDF = new FilterComponentWithMapPartitions(filterEntity, cp).createComponent()
+    val rows = Bucket(Fields(List("col1", "col2", "col3")), filterDF.get("out0").get).result()
+    assertThat(rows(0), is(Row("C1R1", "C2R2", "C3R2")))
+
+  }
+
+  @Test
+  def TestFilterWithOnlyUnusedPort(): Unit = {
+    val df1 = new DataBuilder(Fields(List("col1", "col2", "col3")).applyTypes(List(classOf[String], classOf[String], classOf[String])))
+      .addData(List("C1R1", "C2R1", "C3R1"))
+      .addData(List("C1R1", "C2R2", "C3R2"))
+      .build()
+
+    val operationProperties: Properties = new Properties
+    operationProperties.put("Filter", "filter")
+
+    val operationInputFields: Array[String] = Array("col1")
+    val operationClass: String = "hydrograph.engine.transformation.userfunctions.filter.CustomFilterForFilterComponent"
+
+    val filterEntity: FilterEntity = new FilterEntity
+    filterEntity.setComponentId("filterTest")
+
+    val operation: Operation = new Operation
+    operation.setOperationClass(operationClass)
+    operation.setOperationInputFields(operationInputFields)
+    operation.setOperationProperties(operationProperties)
+    filterEntity.setOperation(operation)
+
+    val outSocketList: util.List[OutSocket] = new util.ArrayList[OutSocket]
+    outSocketList.add(new OutSocket("unused1", "unused"))
+    filterEntity.setOutSocketList(outSocketList)
+
+    val cp = new BaseComponentParams
+    cp.addinputDataFrame(df1)
+    cp.addSchemaFields(Array(new SchemaField("col1", "java.lang.String"), new SchemaField("col2", "java.lang.String"), new SchemaField("col3", "java.lang.String"), new SchemaField("col3", "java.lang.String")))
+
+    val filterDF = new FilterComponentWithMapPartitions(filterEntity, cp).createComponent()
+    val rows = Bucket(Fields(List("col1", "col2", "col3")), filterDF.get("unused1").get).result()
+    assertThat(rows(0), is(Row("C1R1", "C2R2", "C3R2")))
+
+  }
+
+  @Test
+  def TestFilterWithOutAndUnusedPort(): Unit = {
+    val df1 = new DataBuilder(Fields(List("col1", "col2", "col3")).applyTypes(List(classOf[String], classOf[String], classOf[String])))
+      .addData(List("C1R1", "C2R1", "C3R1"))
+      .addData(List("C1R2", "C2R2", "C3R2"))
+      .build()
+
+    val operationProperties: Properties = new Properties
+
+    operationProperties.put("Filter", "filter")
+
+    val operationInputFields: Array[String] = Array("col1")
+    val operationClass: String = "hydrograph.engine.transformation.userfunctions.filter.CustomFilterForFilterComponent"
+    val filterEntity: FilterEntity = new FilterEntity
+    filterEntity.setComponentId("filterTest")
+    val operation: Operation = new Operation
+    operation.setOperationClass(operationClass)
+    operation.setOperationInputFields(operationInputFields)
+    operation.setOperationProperties(operationProperties)
+    filterEntity.setOperation(operation)
+
+    val outSocketList: util.List[OutSocket] = new util.ArrayList[OutSocket]
+    outSocketList.add(new OutSocket("unused1", "unused"))
+    outSocketList.add(new OutSocket("used1", "out"))
+    filterEntity.setOutSocketList(outSocketList)
+
+    val cp = new BaseComponentParams
+    cp.addinputDataFrame(df1)
+    cp.addSchemaFields(Array(new SchemaField("col1", "java.lang.String"), new SchemaField("col2", "java.lang.String"), new SchemaField("col3", "java.lang.String"), new SchemaField("col3", "java.lang.String")))
+
+    val FilterDF = new FilterComponentWithMapPartitions(filterEntity, cp).createComponent()
+    val unusedRows = Bucket(Fields(List("col1", "col2", "col3")), FilterDF.get("unused1").get).result()
+
+    val usedRows = Bucket(Fields(List("col1", "col2", "col3")), FilterDF.get("used1").get).result()
+
+
+    assertThat(unusedRows.size, is(1))
+    assertThat(unusedRows(0), is(Row("C1R1", "C2R1", "C3R1")))
+
+    // assert the actual results with expected results
+    assertThat(usedRows.size, is(1))
+    assertThat(usedRows(0), is(Row("C1R2", "C2R2", "C3R2")))
+
+
+  }
+  @Test
+  def TestFilterWithOutOperationInputFields(): Unit = {
+    val df1 = new DataBuilder(Fields(List("col1", "col2", "col3")).applyTypes(List(classOf[String], classOf[String], classOf[String])))
+      .addData(List("C1R1", "C2R1", "C3R1"))
+      .addData(List("C1R2", "C2R2", "C3R2"))
+      .build()
+
+    val operationProperties: Properties = new Properties
+
+    operationProperties.put("Filter", "10")
+
+    val operationClass: String = "hydrograph.engine.transformation.userfunctions.filter.FilterWithEmptyOperationFields"
+    val filterEntity: FilterEntity = new FilterEntity
+    filterEntity.setComponentId("filterTest")
+    val operation: Operation = new Operation
+    operation.setOperationClass(operationClass)
+    operation.setOperationProperties(operationProperties)
+    filterEntity.setOperation(operation)
+
+    val outSocketList: util.List[OutSocket] = new util.ArrayList[OutSocket]
+    outSocketList.add(new OutSocket("unused1", "unused"))
+    outSocketList.add(new OutSocket("used1", "out"))
+    filterEntity.setOutSocketList(outSocketList)
+
+    val cp = new BaseComponentParams
+    cp.addinputDataFrame(df1)
+    cp.addSchemaFields(Array(new SchemaField("col1", "java.lang.String"), new SchemaField("col2", "java.lang.String"), new SchemaField("col3", "java.lang.String"), new SchemaField("col3", "java.lang.String")))
+
+    val FilterDF = new FilterComponentWithMapPartitions(filterEntity, cp).createComponent()
+    val unusedRows = Bucket(Fields(List("col1", "col2", "col3")), FilterDF.get("unused1").get).result()
+
+    val usedRows = Bucket(Fields(List("col1", "col2", "col3")), FilterDF.get("used1").get).result()
+
+
+    assertThat(unusedRows.size, is(2))
+    assertThat(usedRows.size, is(0))
+  }
+}

--- a/hydrograph.engine/hydrograph.engine.transformation/src/main/java/hydrograph/engine/transformation/standardfunctions/DateFunctions.java
+++ b/hydrograph.engine/hydrograph.engine.transformation/src/main/java/hydrograph/engine/transformation/standardfunctions/DateFunctions.java
@@ -33,277 +33,285 @@ import java.util.Date;
  */
 public class DateFunctions {
 
-	/**
-	 * Returns number of days since 1st January 1900
-	 * 
-	 * @return number of days since 1st January 1900
-	 */
-	public static <T> Integer today() {
-		int date = 0;
-		try {
-			SimpleDateFormat formatter = new SimpleDateFormat("dd MM yyyy");
-			Date d1 = formatter.parse("1 01 1900");
-			Date d2 = new Date();
-			int DateFraction = (1000 * 60 * 60 * 24);
-			date = (int) ((d2.getTime() - d1.getTime()) / DateFraction);
-		} catch (Exception e) {
-			// since we are parsing static date value, parse function will never
-			// throw exception
-		}
-		return date;
-	}
+    /**
+     * Returns number of days since 1st January 1900
+     *
+     * @return number of days since 1st January 1900
+     */
+    public static <T> Integer today() {
+        int date = 0;
+        try {
+            SimpleDateFormat formatter = new SimpleDateFormat("dd MM yyyy");
+            Date d1 = formatter.parse("1 01 1900");
+            Date d2 = new Date();
+            int DateFraction = (1000 * 60 * 60 * 24);
+            date = (int) ((d2.getTime() - d1.getTime()) / DateFraction);
+        } catch (Exception e) {
+            // since we are parsing static date value, parse function will never
+            // throw exception
+        }
+        return date;
+    }
 
-	/**
-	 * Returns current date and time in yyyyMMddHmmssS format
-	 * 
-	 * @return current date and time in yyyyMMddHmmssS format
-	 */
-	@SuppressWarnings("unchecked")
-	public static <T> T now() {
-		return (T) now("yyyyMMddHmmssS");
-	}
+    /**
+     * Returns current date and time in yyyyMMddHmmssS format
+     *
+     * @return current date and time in yyyyMMddHmmssS format
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T now() {
+        return (T) now("yyyyMMddHmmssS");
+    }
 
-	/**
-	 * Returns current date and time in the required format
-	 * 
-	 * @param dateFormat the format for the date
-	 * @return current date and time in the required format
-	 */
-	public static String now(String dateFormat) {
-		DateFormat sdf = new SimpleDateFormat(dateFormat);
-		Date date = new Date();
-		return sdf.format(date);
-	}
+    /**
+     * Returns current date and time in the required format
+     *
+     * @param dateFormat the format for the date
+     * @return current date and time in the required format
+     */
+    public static String now(String dateFormat) {
+        DateFormat sdf = new SimpleDateFormat(dateFormat);
+        Date date = new Date();
+        return sdf.format(date);
+    }
 
-	/**
-	 * Formats and converts a date value into string representation in the
-	 * desired new date format
-	 * 
-	 * @param inputValue
-	 *            the date value in old format
-	 * @param oldFormat
-	 *            the date format of the date passed in {@code inputValue}
-	 * @param newFormat
-	 *            the desired date format
-	 * @return string representation of date in new date format
-	 *         <p>
-	 *         the method returns null if any parameter is null
-	 * @deprecated This method is deprecated, Use
-	 *             {@link DateFunctions#dateFormatter(String inputValue, String oldFormat, String newFormat)}
-	 *             instead
-	 * @throws ParseException
-	 *             if the date value passed in {@code inputValue} does not match
-	 *             the {@code oldFormat}
-	 */
-	@Deprecated
-	public static <T> String dateFormatter(T inputValue, String oldFormat, String newFormat) throws ParseException {
-		if (inputValue == null || oldFormat == null || newFormat == null)
-			return null;
+    /**
+     * Formats and converts a date value into string representation in the
+     * desired new date format
+     *
+     * @param inputValue
+     *            the date value in old format
+     * @param oldFormat
+     *            the date format of the date passed in {@code inputValue}
+     * @param newFormat
+     *            the desired date format
+     * @return string representation of date in new date format
+     *         <p>
+     *         the method returns null if any parameter is null
+     * @deprecated This method is deprecated, Use
+     *             {@link DateFunctions#dateFormatter(String inputValue, String oldFormat, String newFormat)}
+     *             instead
+     * @throws ParseException
+     *             if the date value passed in {@code inputValue} does not match
+     *             the {@code oldFormat}
+     */
+    @Deprecated
+    public static <T> String dateFormatter(T inputValue, String oldFormat, String newFormat) {
+        if (inputValue == null || oldFormat == null || newFormat == null)
+            return null;
+        String newDateString = null;
+        try {
+            String oldDateString = String.valueOf(StandardFunctionHelper.convertComparableObjectToString(inputValue));
+            SimpleDateFormat sdf = new SimpleDateFormat(oldFormat);
+            sdf.setLenient(false);
+            Date date = null;
+            date = sdf.parse(oldDateString);
+            sdf.applyPattern(newFormat);
+            newDateString = sdf.format(date);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+        return newDateString;
+    }
 
-		String oldDateString = String.valueOf(StandardFunctionHelper.convertComparableObjectToString(inputValue));
-		String newDateString = null;
+    /**
+     * Formats and converts a date value into string representation in the
+     * desired new date format
+     *
+     * @param inputValue
+     *            the date value in old format
+     * @param oldFormat
+     *            the date format of the date passed in {@code inputValue}
+     * @param newFormat
+     *            the desired date format
+     * @return string representation of date in new date format
+     *         <p>
+     *         the method returns null if any parameter is null
+     * @throws ParseException
+     *             if the date value passed in {@code inputValue} does not match
+     *             the {@code oldFormat}
+     */
+    public static String dateFormatter(String inputValue, String oldFormat, String newFormat) {
+        if (inputValue == null || oldFormat == null || newFormat == null)
+            return null;
+        String newDateString = null;
+        try {
+            SimpleDateFormat sdf = new SimpleDateFormat(oldFormat);
+            sdf.setLenient(false);
+            Date date = null;
 
-		SimpleDateFormat sdf = new SimpleDateFormat(oldFormat);
-		sdf.setLenient(false);
-		Date date = null;
-		date = sdf.parse(oldDateString);
-		sdf.applyPattern(newFormat);
-		newDateString = sdf.format(date);
+            date = sdf.parse(inputValue);
 
-		return newDateString;
-	}
+            sdf.applyPattern(newFormat);
+            newDateString = sdf.format(date);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return newDateString;
+    }
 
-	/**
-	 * Formats and converts a date value into string representation in the
-	 * desired new date format
-	 * 
-	 * @param inputValue
-	 *            the date value in old format
-	 * @param oldFormat
-	 *            the date format of the date passed in {@code inputValue}
-	 * @param newFormat
-	 *            the desired date format
-	 * @return string representation of date in new date format
-	 *         <p>
-	 *         the method returns null if any parameter is null
-	 * @throws ParseException
-	 *             if the date value passed in {@code inputValue} does not match
-	 *             the {@code oldFormat}
-	 */
-	public static String dateFormatter(String inputValue, String oldFormat, String newFormat) throws ParseException {
-		if (inputValue == null || oldFormat == null || newFormat == null)
-			return null;
-		String newDateString = null;
-
-		SimpleDateFormat sdf = new SimpleDateFormat(oldFormat);
-		sdf.setLenient(false);
-		Date date = null;
-		date = sdf.parse(inputValue);
-		sdf.applyPattern(newFormat);
-		newDateString = sdf.format(date);
-
-		return newDateString;
-	}
-
-	/**
-	 * Formats and converts a date value into string representation in the
-	 * desired new date format
-	 * 
-	 * @param inputValue
-	 *            the date value in old format
-	 * @param oldFormat
-	 *            the date format of the date passed in {@code inputValue}
-	 * @param newFormat
-	 *            the desired date format
-	 * @return string representation of date in new date format
-	 *         <p>
-	 *         the method returns null if any parameter is null
-	 * @throws ParseException
-	 *             if the date value passed in {@code inputValue} does not match
-	 *             the {@code oldFormat}
-	 */
-	public static String dateFormatter(Date inputValue, String oldFormat, String newFormat) throws ParseException {
-		if (inputValue == null || oldFormat == null || newFormat == null)
-			return null;
+    /**
+     * Formats and converts a date value into string representation in the
+     * desired new date format
+     *
+     * @param inputValue
+     *            the date value in old format
+     * @param oldFormat
+     *            the date format of the date passed in {@code inputValue}
+     * @param newFormat
+     *            the desired date format
+     * @return string representation of date in new date format
+     *         <p>
+     *         the method returns null if any parameter is null
+     * @throws ParseException
+     *             if the date value passed in {@code inputValue} does not match
+     *             the {@code oldFormat}
+     */
+    public static String dateFormatter(Date inputValue, String oldFormat, String newFormat)  {
+        if (inputValue == null || oldFormat == null || newFormat == null)
+            return null;
 
         String newDateString = null;
         SimpleDateFormat sdf = new SimpleDateFormat(newFormat);
         sdf.setLenient(false);
         newDateString = sdf.format(inputValue);
 
-		return newDateString;
-	}
+        return newDateString;
+    }
 
-	/**
-	 * Returns a date object from a string date value
-	 * 
-	 * @param inputDateInStringFormat
-	 *            the date value in string
-	 * @param dateFormat
-	 *            the date format of the date value passed in
-	 *            {@code inputDateInStringFormat}
-	 * @return a date object of the corresponding date value
-	 *         <p>
-	 *         the method returns null if any parameter is null
-	 * @deprecated This method is deprecated, Use
-	 *             {@link DateFunctions#getDateFromString(String inputDateInStringFormat, String dateFormat)}
-	 *             instead
-	 * @throws ParseException
-	 *             if the date value passed in {@code inputDateInStringFormat}
-	 *             does not match the {@code dateFormat}
-	 */
-	@Deprecated
-	public static <T> Date getDateFromString(T inputDateInStringFormat, String dateFormat) throws ParseException {
-		if (inputDateInStringFormat == null || dateFormat == null)
-			return null;
+    /**
+     * Returns a date object from a string date value
+     *
+     * @param inputDateInStringFormat
+     *            the date value in string
+     * @param dateFormat
+     *            the date format of the date value passed in
+     *            {@code inputDateInStringFormat}
+     * @return a date object of the corresponding date value
+     *         <p>
+     *         the method returns null if any parameter is null
+     * @deprecated This method is deprecated, Use
+     *             {@link DateFunctions#getDateFromString(String inputDateInStringFormat, String dateFormat)}
+     *             instead
+     * @throws ParseException
+     *             if the date value passed in {@code inputDateInStringFormat}
+     *             does not match the {@code dateFormat}
+     */
+    @Deprecated
+    public static <T> Date getDateFromString(T inputDateInStringFormat, String dateFormat) throws ParseException {
+        if (inputDateInStringFormat == null || dateFormat == null)
+            return null;
 
-		SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
-		sdf.setLenient(false);
-		Date date = sdf.parse((String) inputDateInStringFormat);
-		return date;
-	}
+        SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
+        sdf.setLenient(false);
+        Date date = sdf.parse((String) inputDateInStringFormat);
+        return date;
+    }
 
-	/**
-	 * Returns a date object from a string date value
-	 * 
-	 * @param inputDateInStringFormat
-	 *            the date value in string
-	 * @param dateFormat
-	 *            the date format of the date value passed in
-	 *            {@code inputDateInStringFormat}
-	 * @return a date object of the corresponding date value
-	 *         <p>
-	 *         the method returns null if any parameter is null
-	 * @throws ParseException
-	 *             if the date value passed in {@code inputDateInStringFormat}
-	 *             does not match the {@code dateFormat}
-	 */
-	public static Date getDateFromString(String inputDateInStringFormat, String dateFormat) throws ParseException {
-		if (inputDateInStringFormat == null || dateFormat == null)
-			return null;
+    /**
+     * Returns a date object from a string date value
+     *
+     * @param inputDateInStringFormat
+     *            the date value in string
+     * @param dateFormat
+     *            the date format of the date value passed in
+     *            {@code inputDateInStringFormat}
+     * @return a date object of the corresponding date value
+     *         <p>
+     *         the method returns null if any parameter is null
+     * @throws ParseException
+     *             if the date value passed in {@code inputDateInStringFormat}
+     *             does not match the {@code dateFormat}
+     */
+    public static Date getDateFromString(String inputDateInStringFormat, String dateFormat){
+        if (inputDateInStringFormat == null || dateFormat == null)
+            return null;
 
-		SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
-		sdf.setLenient(false);
-		Date date = sdf.parse(inputDateInStringFormat);
-		return date;
-	}
+        SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
+        sdf.setLenient(false);
+        Date date = null;
+        try {
+            date = sdf.parse(inputDateInStringFormat);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+        return date;
+    }
 
-	/**
-	 * Returns a string value of the date
-	 * 
-	 * @param inputDate
-	 *            the date to fetch the string value
-	 * @param dateFormat
-	 *            the date format of the date value passed in {@code inputDate}
-	 * @return a string value of the date
-	 *         <p>
-	 *         the method returns null if any parameter is null
-	 * 
-	 * @throws ParseException
-	 *             if the date value passed in {@code inputDate} does not match
-	 *             the {@code dateFormat}
-	 */
-	public static <T> String getStringDateFromDateObject(T inputDate, String dateFormat) throws ParseException {
-		if (inputDate == null || dateFormat == null)
-			return null;
+    /**
+     * Returns a string value of the date
+     *
+     * @param inputDate
+     *            the date to fetch the string value
+     * @param dateFormat
+     *            the date format of the date value passed in {@code inputDate}
+     * @return a string value of the date
+     *         <p>
+     *         the method returns null if any parameter is null
+     *
+     * @throws ParseException
+     *             if the date value passed in {@code inputDate} does not match
+     *             the {@code dateFormat}
+     */
+    public static <T> String getStringDateFromDateObject(T inputDate, String dateFormat) {
+        if (inputDate == null || dateFormat == null)
+            return null;
 
-		SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
-		sdf.setLenient(false);
-		String stringDate = sdf.format(inputDate);
-		return stringDate;
-	}
+        SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
+        sdf.setLenient(false);
+        String stringDate = sdf.format(inputDate);
+        return stringDate;
+    }
 
-	/**
-	 * Returns a string value of the date
-	 * 
-	 * @param inputDate
-	 *            the date to fetch the string value
-	 * @param dateFormat
-	 *            the date format of the date value passed in {@code inputDate}
-	 * @return a string value of the date
-	 *         <p>
-	 *         the method returns null if any parameter is null
-	 * @throws ParseException
-	 *             if the date value passed in {@code inputDate} does not match
-	 *             the {@code dateFormat}
-	 */
-	public static String getStringDateFromDateObject(Date inputDate, String dateFormat) throws ParseException {
-		if (inputDate == null || dateFormat == null)
-			return null;
+    /**
+     * Returns a string value of the date
+     *
+     * @param inputDate
+     *            the date to fetch the string value
+     * @param dateFormat
+     *            the date format of the date value passed in {@code inputDate}
+     * @return a string value of the date
+     *         <p>
+     *         the method returns null if any parameter is null
+     * @throws ParseException
+     *             if the date value passed in {@code inputDate} does not match
+     *             the {@code dateFormat}
+     */
+    public static String getStringDateFromDateObject(Date inputDate, String dateFormat)  {
+        if (inputDate == null || dateFormat == null)
+            return null;
 
-		SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
-		sdf.setLenient(false);
-		String stringDate = sdf.format(inputDate);
-		return stringDate;
-	}
+        SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
+        sdf.setLenient(false);
+        String stringDate = sdf.format(inputDate);
+        return stringDate;
+    }
 
-	/**
-	 * Validates the string date value to the format specified
-	 * 
-	 * @param inputDate
-	 *            the date value in string to be validated
-	 * @param dateFormat
-	 *            the date format to validate the string value against
-	 * @return <b>{@code true}</b> if the date value passed in {@code inputDate}
-	 *         matches the date format passed in {@code dateFormat}
-	 *         <p>
-	 *         <b>{@code false}</b> if the date value passed in
-	 *         {@code inputDate} does not match the date format passed in
-	 *         {@code dateFormat}
-	 */
-	public static boolean validateStringDate(String inputDate, String dateFormat) {
-		if (dateFormat != null && !dateFormat.equals("") && inputDate != null && !inputDate.equals("")) {
-			SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
-			sdf.setLenient(false);
-			try {
-				sdf.parse(inputDate);
-				return true;
-			} catch (ParseException e) {
-				return false;
-			}
-		}
-		return false;
-	}
+    /**
+     * Validates the string date value to the format specified
+     *
+     * @param inputDate  the date value in string to be validated
+     * @param dateFormat the date format to validate the string value against
+     * @return <b>{@code true}</b> if the date value passed in {@code inputDate}
+     *         matches the date format passed in {@code dateFormat}
+     *         <p>
+     *         <b>{@code false}</b> if the date value passed in
+     *         {@code inputDate} does not match the date format passed in
+     *         {@code dateFormat}
+     */
+    public static boolean validateStringDate(String inputDate, String dateFormat) {
+        if (dateFormat != null && !dateFormat.equals("") && inputDate != null && !inputDate.equals("")) {
+            SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
+            sdf.setLenient(false);
+            try {
+                sdf.parse(inputDate);
+                return true;
+            } catch (ParseException e) {
+                return false;
+            }
+        }
+        return false;
+    }
 
     /**
      * Returns an integer value which holds the day value retrieved from {@code date} parameter
@@ -424,10 +432,15 @@ public class DateFunctions {
      * @param fromDate the date from which the difference is to be calculated
      * @param toDate   the date to which the difference is to be calculated
      * @return the difference of days between {@code fromDate} to {@code toDate}
+     * if either of {@code fromDate} or {@code toDate} are null return null
      */
     public static Integer getDayDifference(Date fromDate, Date toDate) {
-        LocalDateTime firstDate = LocalDateTime.ofInstant(fromDate.toInstant(), ZoneId.systemDefault());
-        LocalDateTime secondDate = LocalDateTime.ofInstant(toDate.toInstant(), ZoneId.systemDefault());
+        if (fromDate == null || toDate == null)
+            return null;
+        Date localFromDate = new Date(fromDate.getTime());
+        Date localToDate = new Date(toDate.getTime());
+        LocalDateTime firstDate = LocalDateTime.ofInstant(localFromDate.toInstant(), ZoneId.systemDefault());
+        LocalDateTime secondDate = LocalDateTime.ofInstant(localToDate.toInstant(), ZoneId.systemDefault());
         long daysLong = Math.abs(ChronoUnit.DAYS.between(firstDate, secondDate));
         return (int) daysLong;
     }
@@ -438,10 +451,17 @@ public class DateFunctions {
      * @param fromDate the date from which the difference is to be calculated
      * @param toDate   the date to which the difference is to be calculated
      * @return the difference of months between {@code fromDate} and {@code toDate}
+     * if either of {@code fromDate} or {@code toDate} are null return null
      */
     public static Integer getMonthDifference(Date fromDate, Date toDate) {
-        LocalDateTime firstDate = LocalDateTime.ofInstant(fromDate.toInstant(), ZoneId.systemDefault());
-        LocalDateTime secondDate = LocalDateTime.ofInstant(toDate.toInstant(), ZoneId.systemDefault());
+
+        if (fromDate == null || toDate == null)
+            return null;
+        Date localFromDate = new Date(fromDate.getTime());
+        Date localToDate = new Date(toDate.getTime());
+
+        LocalDateTime firstDate = LocalDateTime.ofInstant(localFromDate.toInstant(), ZoneId.systemDefault());
+        LocalDateTime secondDate = LocalDateTime.ofInstant(localToDate.toInstant(), ZoneId.systemDefault());
         long months = Math.abs(ChronoUnit.MONTHS.between(firstDate, secondDate));
         return (int) months;
     }
@@ -452,10 +472,17 @@ public class DateFunctions {
      * @param fromDate the date from which the difference is to be calculated
      * @param toDate   the date to which the difference is to be calculated
      * @return difference of years between {@code fromDate} and {@code toDate}
+     * if either of {@code fromDate} or {@code toDate} are null return null
      */
     public static Integer getYearDifference(Date fromDate, Date toDate) {
-        LocalDateTime firstDate = LocalDateTime.ofInstant(fromDate.toInstant(), ZoneId.systemDefault());
-        LocalDateTime secondDate = LocalDateTime.ofInstant(toDate.toInstant(), ZoneId.systemDefault());
+
+        if (fromDate == null || toDate == null)
+            return null;
+        Date localFromDate = new Date(fromDate.getTime());
+        Date localToDate = new Date(toDate.getTime());
+
+        LocalDateTime firstDate = LocalDateTime.ofInstant(localFromDate.toInstant(), ZoneId.systemDefault());
+        LocalDateTime secondDate = LocalDateTime.ofInstant(localToDate.toInstant(), ZoneId.systemDefault());
         long years = Math.abs(ChronoUnit.YEARS.between(firstDate, secondDate));
         return (int) (long) years;
     }
@@ -471,7 +498,8 @@ public class DateFunctions {
     public static Date addDaysToDate(Date date, int days) {
         if(date == null)
             return null;
-        LocalDateTime ldt = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+        Date local = new Date(date.getTime());
+        LocalDateTime ldt = LocalDateTime.ofInstant(local.toInstant(), ZoneId.systemDefault());
         Date newDate = Date.from(ldt.plusDays((long) days).atZone(ZoneId.systemDefault()).toInstant());
         return newDate;
     }
@@ -624,9 +652,13 @@ public class DateFunctions {
      * @param date       the date to which weeks are to be added
      * @param weeks weeks to be added to given {@code date}
      * @return date after adding {@code weeks} to {@code date}
+     * if {@code date} is null then return null
      */
     public static Date addWeeksToDate(Date date, int weeks) {
-        LocalDateTime localDateTime = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+        if (date == null)
+            return null;
+        Date localDate = new Date(date.getTime());
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(localDate.toInstant(), ZoneId.systemDefault());
         Date newDate = Date.from(localDateTime.plusWeeks((long) weeks).atZone(ZoneId.systemDefault()).toInstant());
         return newDate;
     }
@@ -637,9 +669,13 @@ public class DateFunctions {
      * @param date        the date to which months are to be added
      * @param months months to be added to given {@code date}
      * @return date after adding {@code months} to {@code date}
+     * if {@code date} is null return null
      */
     public static Date addMonthsToDate(Date date, int months) {
-        LocalDateTime localDateTime = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+        if (date == null)
+            return null;
+        Date localDate = new Date(date.getTime());
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(localDate.toInstant(), ZoneId.systemDefault());
         Date newDate = Date.from(localDateTime.plusMonths((long) months).atZone(ZoneId.systemDefault()).toInstant());
         return newDate;
     }
@@ -650,9 +686,15 @@ public class DateFunctions {
      * @param date       the date to which months are to be added
      * @param years years to be added to given {@code date}
      * @return date after adding  years to it
+     * if {@code date} is null return null
      */
     public static Date addYearsToDate(Date date, int years) {
-        LocalDateTime localDateTime = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+
+        if (date == null)
+            return null;
+        Date localDate = new Date(date.getTime());
+
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(localDate.toInstant(), ZoneId.systemDefault());
         Date newDate = Date.from(localDateTime.plusYears((long) years).atZone(ZoneId.systemDefault()).toInstant());
         return newDate;
     }
@@ -715,25 +757,26 @@ public class DateFunctions {
      *
      * @param timeInMillisecs input date in milliseconds
      * @return returns date value for time in milliseconds
-	 * returns null if {@code timeInMillisecs} is null
+     * returns null if {@code timeInMillisecs} is null
      */
     public static Date toDate(Long timeInMillisecs) {
 
-    	if(timeInMillisecs==null)
-    		return null;
+        if(timeInMillisecs==null)
+            return null;
 
         return new Date(timeInMillisecs);
     }
 
     /**
      * Returns the date for {@code year},{@code month} and {@code day}
-     * @param year input year of date
+     *
+     * @param year  input year of date
      * @param month input month of date
-     * @param day input day of date
-     * @retrun returns date for give {@code year},(@code month} and {@day}
-	 *   return null if either of {@code year}, {@code month} or {@code day} are null
+     * @param day   input day of date
      * @throws DateTimeException if the value of any field is out of range,
-     *  or if the day-of-month is invalid for the month-year
+     *                           or if the day-of-month is invalid for the month-year
+     * @retrun returns date for give {@code year},(@code month} and {@day}
+     * return null if either of {@code year}, {@code month} or {@code day} are null
      */
     public static Date toDate(Integer year, Integer month,Integer day) throws DateTimeException {
 

--- a/hydrograph.engine/hydrograph.engine.transformation/src/main/java/hydrograph/engine/transformation/standardfunctions/ForceError.java
+++ b/hydrograph.engine/hydrograph.engine.transformation/src/main/java/hydrograph/engine/transformation/standardfunctions/ForceError.java
@@ -26,7 +26,7 @@ public class ForceError {
 	 * @param errorMessage
 	 *            the error message to log
 	 */
-	public static void raiseError(String errorMessage) {
+	public static <T> T raiseError(String errorMessage) {
 		errorMessage = "Error raised due to force_error condition." + "\n"
 				+ errorMessage;
 		throw new RuntimeException(errorMessage);

--- a/hydrograph.engine/hydrograph.engine.transformation/src/main/java/hydrograph/engine/transformation/standardfunctions/NumericFunctions.java
+++ b/hydrograph.engine/hydrograph.engine.transformation/src/main/java/hydrograph/engine/transformation/standardfunctions/NumericFunctions.java
@@ -209,7 +209,105 @@ public class NumericFunctions {
         return r.nextInt(n1);
     }
 
+
+    /**
+     * @Deprecated Method
+     * Converts {@code inputValue} to Double value
+     *
+     * @param inputValue comparable to be converted to Double
+     * @return converted value of {@code inputValue} to Double
+     * if {@code inputValue} is null return null
+     *
+     * Recommended to use:
+     *          Double toDouble(Float inputValue)
+     *          Double toDouble(Integer inputValue)
+     *          Double toDouble(Long inputValue)
+     *          Double toDouble(Short inputValue)
+     *          Double toDouble(BigDecimal inputValue)
+     *          Double toDouble(String inputValue)
+     *
+     */
     public static <T> Double getDoubleFromComparable(T inputValue) {
+        return Double.parseDouble(convertComparableObjectToString(inputValue));
+    }
+
+    /**
+     * Converts {@code inputValue} to Double value
+     *
+     * @param inputValue to be converted to Double
+     * @return converted value of {@code inputValue} to Double
+     * if {@code inputValue} is null return null
+     */
+    public static Double toDouble(Float inputValue) {
+        if (inputValue == null)
+            return null;
+        return new Double(inputValue);
+    }
+
+    /**
+     * Converts {@code inputValue} to Double value
+     *
+     * @param inputValue to be converted to Double
+     * @return converted value of {@code inputValue} to Double
+     * if {@code inputValue} is null return null
+     */
+    public static Double toDouble(Integer inputValue) {
+        if (inputValue == null)
+            return null;
+        return new Double(inputValue);
+    }
+
+
+    /**
+     * Converts {@code inputValue} to Double value
+     *
+     * @param inputValue to be converted to Double
+     * @return converted value of {@code inputValue} to Double
+     * if {@code inputValue} is null return null
+     */
+    public static Double toDouble(String inputValue) {
+        if (inputValue == null)
+            return null;
+        return Double.parseDouble(inputValue);
+    }
+
+    /**
+     * Converts {@code inputValue} to Double value
+     *
+     * @param inputValue to be converted to Double
+     * @return converted value of {@code inputValue} to Double
+     * if {@code inputValue} is null return null
+     */
+    public static Double toDouble(Long inputValue) {
+        if (inputValue == null)
+            return null;
+        return new Double(inputValue);
+    }
+
+    /**
+     * Converts {@code inputValue} to Double value
+     *
+     * @param inputValue to be converted to Double
+     * @return converted value of {@code inputValue} to Double
+     * if {@code inputValue} is null return null
+     */
+    public static Double toDouble(Short inputValue) {
+        if (inputValue == null)
+            return null;
+        return new Double(inputValue);
+    }
+
+
+    /**
+     * Converts {@code inputValue} to Double value
+     *
+     * @param inputValue to be converted to Double
+     * @return converted value of {@code inputValue} to Double
+     * if {@code inputValue} is null return null
+     */
+    public static Double toDouble(BigDecimal inputValue) {
+        if (inputValue == null)
+            return null;
         return Double.parseDouble(convertComparableObjectToString(inputValue));
     }
 
@@ -552,10 +650,9 @@ public class NumericFunctions {
      * @param inputValue inputValue string to be converted to integer
      * @return converted value of {@code inputValue} to integer
      * if {@code inputValue} is null return null
-     * @throws NumberFormatException if the string does not contain a
-     *                               parsable integer.
+     *
      */
-    public static Integer toInteger(String inputValue) throws NumberFormatException {
+    public static Integer toInteger(String inputValue)  {
         if (inputValue == null)
             return null;
 
@@ -568,10 +665,9 @@ public class NumericFunctions {
      * @param inputValue string to be converted to float
      * @return converted value of {@code inputValue} to float
      * if {@code inputValue} is null return null
-     * @throws NumberFormatException if the string does not contain a
-     *                               parsable integer.
+     *
      */
-    public static Float toFloat(String inputValue) throws NumberFormatException {
+    public static Float toFloat(String inputValue)  {
         if (inputValue == null)
             return null;
 
@@ -642,12 +738,17 @@ public class NumericFunctions {
      * @throws ParseException if the specified string {@code inputValue}
      *                        cannot be parsed.
      */
-    public static BigDecimal toBigdecimal(String inputValue, int scale) throws ParseException {
+    public static BigDecimal toBigdecimal(String inputValue, int scale) {
         if (inputValue == null)
             return null;
         DecimalFormat decimalFormat = new DecimalFormat();
         decimalFormat.setParseBigDecimal(true);
-        return ((BigDecimal) decimalFormat.parse(inputValue)).setScale(scale, BigDecimal.ROUND_DOWN);
+        try {
+            return ((BigDecimal) decimalFormat.parse(inputValue)).setScale(scale, BigDecimal.ROUND_DOWN);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     /**
@@ -716,7 +817,8 @@ public class NumericFunctions {
      * @throws ParseException if the specified string {@code inputValue}
      *                        cannot be parsed.
      */
-    public static BigDecimal toBigdecimal(char[] inputValue, int scale) throws ParseException {
+    @Deprecated
+    public static BigDecimal toBigdecimal(char[] inputValue, int scale)  {
         if (inputValue == null)
             return null;
 

--- a/hydrograph.engine/hydrograph.engine.transformation/src/main/java/hydrograph/engine/transformation/userfunctions/base/FilterBase.java
+++ b/hydrograph.engine/hydrograph.engine.transformation/src/main/java/hydrograph/engine/transformation/userfunctions/base/FilterBase.java
@@ -36,8 +36,8 @@ public interface FilterBase extends Serializable {
 	 * @param inputFields
 	 *            the list of input fields to the filter operation.
 	 */
-	@Deprecated
-	default	void prepare(Properties props, ArrayList<String> inputFields){}
+	//@Deprecated
+	void prepare(Properties props, ArrayList<String> inputFields);
 
 	/**
 	 * This method is the operation function and is called for each input row.
@@ -78,5 +78,5 @@ public interface FilterBase extends Serializable {
 	 * suggests.
 	 */
 	@Deprecated
-	default	void cleanup(){}
+	default void cleanup(){}
 }

--- a/hydrograph.engine/hydrograph.engine.transformation/src/main/java/hydrograph/engine/transformation/userfunctions/filter/FilterWithPrepareFunction.java
+++ b/hydrograph.engine/hydrograph.engine.transformation/src/main/java/hydrograph/engine/transformation/userfunctions/filter/FilterWithPrepareFunction.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright 2017 Capital One Services, LLC and Bitwise, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ *******************************************************************************/
+package hydrograph.engine.transformation.userfunctions.filter;
+
+import hydrograph.engine.transformation.userfunctions.base.FilterBase;
+import hydrograph.engine.transformation.userfunctions.base.ReusableRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Properties;
+
+/**
+ * The Class FilterForXML.
+ *
+ * @author Bitwise
+ *
+ */
+public class FilterWithPrepareFunction implements FilterBase {
+
+	//private static final int DEFAULT_VALUE = 0;
+	private static Logger LOG = LoggerFactory.getLogger(Filter.class);
+
+	String FilterString = "";
+
+	@Override
+	public void prepare(Properties props, ArrayList<String> inputFields) {
+		String fltrStr = props.getProperty("Filter");    // DEFAULT_VALUE;
+		FilterString = (fltrStr != null ? fltrStr : FilterString);
+
+	}
+
+	@Override
+	public boolean isRemove(ReusableRow reusableRow) {
+		//return reusableRow.getInteger("count") > value;
+		return reusableRow.getString("Choice").equals(FilterString);
+
+		/*
+		 * Long pin=reusableRow.getLong(0); return pin==400101 ;
+		 */
+	}
+
+	@Override
+	public void cleanup() {
+
+	}
+
+}

--- a/hydrograph.engine/hydrograph.engine.transformation/src/test/java/hydrograph/engine/transformation/standardfunctions/DateFuncitonsTest.java
+++ b/hydrograph.engine/hydrograph.engine.transformation/src/test/java/hydrograph/engine/transformation/standardfunctions/DateFuncitonsTest.java
@@ -41,14 +41,9 @@ public class DateFuncitonsTest {
 	@Test
 	public void itShouldFormatTheDateFromString() {
 		String actual = null;
-		try {
-			actual = DateFunctions.dateFormatter("20150512", "yyyyMMdd",
-					"dd-MM-yyyy");
-		} catch (ParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		String expectedDt = "12-05-2015";
+        actual = DateFunctions.dateFormatter("20150512", "yyyyMMdd",
+                "dd-MM-yyyy");
+        String expectedDt = "12-05-2015";
 
 		Assert.assertEquals(expectedDt, actual);
 	}
@@ -56,14 +51,9 @@ public class DateFuncitonsTest {
 	@Test
 	public void itShouldFormatTheDateFromDecimal() {
 		String actual = null;
-		try {
-			actual = DateFunctions.dateFormatter(20150512, "yyyyMMdd",
-					"yyyy-MM-dd");
-		} catch (ParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		String expectedDt = "2015-05-12";
+        actual = DateFunctions.dateFormatter(20150512, "yyyyMMdd",
+                "yyyy-MM-dd");
+        String expectedDt = "2015-05-12";
 
 		Assert.assertEquals(expectedDt, actual);
 	}
@@ -71,14 +61,9 @@ public class DateFuncitonsTest {
 	@Test
 	public void itShouldFormatTheDateFromString1() {
 		String actual = null;
-		try {
-			actual = DateFunctions.dateFormatter("2015/05/12", "yyyy/MM/dd",
-					"dd-MM-yyyy");
-		} catch (ParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		String expectedDt = "12-05-2015";
+        actual = DateFunctions.dateFormatter("2015/05/12", "yyyy/MM/dd",
+                "dd-MM-yyyy");
+        String expectedDt = "12-05-2015";
 
 		Assert.assertEquals(expectedDt, actual);
 	}

--- a/hydrograph.engine/hydrograph.engine.transformation/src/test/java/hydrograph/engine/transformation/standardfunctions/NumericFunctionsTest.java
+++ b/hydrograph.engine/hydrograph.engine.transformation/src/test/java/hydrograph/engine/transformation/standardfunctions/NumericFunctionsTest.java
@@ -16,7 +16,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigDecimal;
-import java.text.ParseException;
 
 /**
  * The Class NumericFunctionsTest.
@@ -109,16 +108,12 @@ public class NumericFunctionsTest {
         Float float1 = new Float(2421.123);
         Double double1 = new Double(12.2345);
         char[] charArray = {'1', '2', '.', '5'};
-        try {
-            Assert.assertEquals(new BigDecimal(12.39).setScale(2, BigDecimal.ROUND_DOWN), NumericFunctions.toBigdecimal("12.39", 2));
-            Assert.assertEquals(new BigDecimal(integer1), NumericFunctions.toBigdecimal(integer1));
-            Assert.assertEquals(new BigDecimal(long1), NumericFunctions.toBigdecimal(long1));
-            Assert.assertEquals(new BigDecimal(float1), NumericFunctions.toBigdecimal(float1));
-            Assert.assertEquals(new BigDecimal(double1).setScale(4, BigDecimal.ROUND_DOWN), NumericFunctions.toBigdecimal(double1));
-            Assert.assertEquals(new BigDecimal(12.5).setScale(1, BigDecimal.ROUND_DOWN), NumericFunctions.toBigdecimal(charArray, 1));
-        } catch (ParseException parseException) {
-            parseException.printStackTrace();
-        }
+        Assert.assertEquals(new BigDecimal(12.39).setScale(2, BigDecimal.ROUND_DOWN), NumericFunctions.toBigdecimal("12.39", 2));
+        Assert.assertEquals(new BigDecimal(integer1), NumericFunctions.toBigdecimal(integer1));
+        Assert.assertEquals(new BigDecimal(long1), NumericFunctions.toBigdecimal(long1));
+        Assert.assertEquals(new BigDecimal(float1), NumericFunctions.toBigdecimal(float1));
+        Assert.assertEquals(new BigDecimal(double1).setScale(4, BigDecimal.ROUND_DOWN), NumericFunctions.toBigdecimal(double1));
+        Assert.assertEquals(new BigDecimal(12.5).setScale(1, BigDecimal.ROUND_DOWN), NumericFunctions.toBigdecimal(charArray, 1));
     }
 
     @Test


### PR DESCRIPTION
For Issue #122 -
1) Enabled the call to the prepare() of the user defined filter class in the FilterComponentWithUDF implementation
2) Added an implementation for FilterComponent which leverages the mapPartitions()
3) Updated the FilterBase class to remove the deprication annotation from the prepare()
4) Added unit test cases for the FilterComponentWithMapPartitions class